### PR TITLE
Repository 작업 전 Firestore 에 대한 Rx Extension 을 추가하였습니다.

### DIFF
--- a/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
+++ b/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		001B1CA82901270C00F5C875 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 001B1CA72901270C00F5C875 /* RxSwift */; };
 		002821EF2901884100717E2C /* ProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821EE2901884100717E2C /* ProcessInfo.swift */; };
 		002821F12901889000717E2C /* UserInfoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821F02901889000717E2C /* UserInfoRepository.swift */; };
+		002821F329018E7700717E2C /* RxSwift+Firestore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821F229018E7700717E2C /* RxSwift+Firestore.swift */; };
+		002821F62901932A00717E2C /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 002821F52901932A00717E2C /* FirebaseFirestoreSwift */; };
 		0062EB7C2900222600B0A6AB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0062EB7B2900222600B0A6AB /* AppDelegate.swift */; };
 		0062EB7E2900222600B0A6AB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0062EB7D2900222600B0A6AB /* SceneDelegate.swift */; };
 		0062EB802900222600B0A6AB /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0062EB7F2900222600B0A6AB /* ViewController.swift */; };
@@ -51,6 +53,7 @@
 		001B1C822901049400F5C875 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
 		002821EE2901884100717E2C /* ProcessInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfo.swift; sourceTree = "<group>"; };
 		002821F02901889000717E2C /* UserInfoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoRepository.swift; sourceTree = "<group>"; };
+		002821F229018E7700717E2C /* RxSwift+Firestore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RxSwift+Firestore.swift"; sourceTree = "<group>"; };
 		0062EB782900222600B0A6AB /* Gom4ziz.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gom4ziz.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0062EB7B2900222600B0A6AB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0062EB7D2900222600B0A6AB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -76,6 +79,7 @@
 				001B1CA82901270C00F5C875 /* RxSwift in Frameworks */,
 				001B1CA62901270C00F5C875 /* RxRelay in Frameworks */,
 				001B1C8829010C4B00F5C875 /* FirebaseFirestore in Frameworks */,
+				002821F62901932A00717E2C /* FirebaseFirestoreSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -106,6 +110,13 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		002821F42901932A00717E2C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		0062EB6F2900222600B0A6AB = {
 			isa = PBXGroup;
 			children = (
@@ -114,6 +125,7 @@
 				0062EB912900222700B0A6AB /* Gom4zizTests */,
 				0062EB9B2900222700B0A6AB /* Gom4zizUITests */,
 				0062EB792900222600B0A6AB /* Products */,
+				002821F42901932A00717E2C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -185,6 +197,7 @@
 			isa = PBXGroup;
 			children = (
 				002821EE2901884100717E2C /* ProcessInfo.swift */,
+				002821F229018E7700717E2C /* RxSwift+Firestore.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -239,6 +252,7 @@
 				001B1CA32901270C00F5C875 /* RxCocoa */,
 				001B1CA52901270C00F5C875 /* RxRelay */,
 				001B1CA72901270C00F5C875 /* RxSwift */,
+				002821F52901932A00717E2C /* FirebaseFirestoreSwift */,
 			);
 			productName = Gom4ziz;
 			productReference = 0062EB782900222600B0A6AB /* Gom4ziz.app */;
@@ -391,6 +405,7 @@
 				0062EB7C2900222600B0A6AB /* AppDelegate.swift in Sources */,
 				002821F12901889000717E2C /* UserInfoRepository.swift in Sources */,
 				0062EB7E2900222600B0A6AB /* SceneDelegate.swift in Sources */,
+				002821F329018E7700717E2C /* RxSwift+Firestore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -806,6 +821,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */;
 			productName = RxSwift;
+		};
+		002821F52901932A00717E2C /* FirebaseFirestoreSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 001B1C8429010C4B00F5C875 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestoreSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
+++ b/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		001B1CA42901270C00F5C875 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 001B1CA32901270C00F5C875 /* RxCocoa */; };
 		001B1CA62901270C00F5C875 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = 001B1CA52901270C00F5C875 /* RxRelay */; };
 		001B1CA82901270C00F5C875 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 001B1CA72901270C00F5C875 /* RxSwift */; };
+		002821EF2901884100717E2C /* ProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821EE2901884100717E2C /* ProcessInfo.swift */; };
+		002821F12901889000717E2C /* UserInfoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821F02901889000717E2C /* UserInfoRepository.swift */; };
 		0062EB7C2900222600B0A6AB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0062EB7B2900222600B0A6AB /* AppDelegate.swift */; };
 		0062EB7E2900222600B0A6AB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0062EB7D2900222600B0A6AB /* SceneDelegate.swift */; };
 		0062EB802900222600B0A6AB /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0062EB7F2900222600B0A6AB /* ViewController.swift */; };
@@ -47,6 +49,8 @@
 		001B1C7E2900FCC800F5C875 /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		001B1C802900FE5B00F5C875 /* PromiseRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromiseRoom.swift; sourceTree = "<group>"; };
 		001B1C822901049400F5C875 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
+		002821EE2901884100717E2C /* ProcessInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfo.swift; sourceTree = "<group>"; };
+		002821F02901889000717E2C /* UserInfoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoRepository.swift; sourceTree = "<group>"; };
 		0062EB782900222600B0A6AB /* Gom4ziz.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gom4ziz.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0062EB7B2900222600B0A6AB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0062EB7D2900222600B0A6AB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -172,6 +176,7 @@
 		0062EBB0290024FB00B0A6AB /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				002821F02901889000717E2C /* UserInfoRepository.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -179,6 +184,7 @@
 		0062EBB12900254600B0A6AB /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				002821EE2901884100717E2C /* ProcessInfo.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -380,8 +386,10 @@
 				001B1C7F2900FCC800F5C875 /* UserInfo.swift in Sources */,
 				001B1C832901049400F5C875 /* MockData.swift in Sources */,
 				0062EB802900222600B0A6AB /* ViewController.swift in Sources */,
+				002821EF2901884100717E2C /* ProcessInfo.swift in Sources */,
 				001B1C812900FE5B00F5C875 /* PromiseRoom.swift in Sources */,
 				0062EB7C2900222600B0A6AB /* AppDelegate.swift in Sources */,
+				002821F12901889000717E2C /* UserInfoRepository.swift in Sources */,
 				0062EB7E2900222600B0A6AB /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Gom4ziz/Gom4ziz/Data/UserInfoRepository.swift
+++ b/Gom4ziz/Gom4ziz/Data/UserInfoRepository.swift
@@ -1,0 +1,15 @@
+//
+//  UserInfoRepository.swift
+//  Gom4ziz
+//
+//  Created by JongHo Park on 2022/10/20.
+//
+
+import Foundation
+import FirebaseFirestore
+import RxSwift
+
+protocol UserInfoRepository {
+    func requestUserInfo(of uid: String) -> Observable<UserInfo>
+    func addUserInfo(userInfo: UserInfo)
+}

--- a/Gom4ziz/Gom4ziz/Extension/ProcessInfo.swift
+++ b/Gom4ziz/Gom4ziz/Extension/ProcessInfo.swift
@@ -1,0 +1,15 @@
+//
+//  ProcessInfo.swift
+//  Gom4ziz
+//
+//  Created by JongHo Park on 2022/10/20.
+//
+
+import Foundation
+
+// 현재 프로세스가 테스트 프로세스인지, 아니면 정상적인 프로덕션 프로세스인지 나타내는 Bool 값을 익스텐션으로 추가
+extension ProcessInfo {
+    var isRunningTests: Bool {
+        environment["XCTestConfigurationFilePath"] != nil
+    }
+}

--- a/Gom4ziz/Gom4ziz/Extension/RxSwift+Firestore.swift
+++ b/Gom4ziz/Gom4ziz/Extension/RxSwift+Firestore.swift
@@ -1,0 +1,83 @@
+//
+//  RxSwift+Firestore.swift
+//  Gom4ziz
+//
+//  Created by JongHo Park on 2022/10/20.
+//
+
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+import RxSwift
+
+enum RxFirestoreError: Error {
+    case documentIsNotExist // document 가 없는 에러
+}
+
+extension Reactive where Base: DocumentReference {
+
+    /// get document snapshot with given document reference
+    /// - Parameter source: FirestoreSource
+    /// - Returns: Observable of document snapshot
+    func document(source: FirestoreSource = .default) -> Observable<DocumentSnapshot> {
+        Observable.create { observer in
+            base.getDocument(source: source) { snapshot, error in
+                guard error == nil else {
+                    observer.onError(error!)
+                    return
+                }
+                guard let snapshot, snapshot.exists else {
+                    observer.onError(RxFirestoreError.documentIsNotExist)
+                    return
+                }
+                observer.onNext(snapshot)
+                observer.onCompleted()
+            }
+            return Disposables.create()
+        }
+    }
+
+    /// get decodable type value with given document reference
+    /// - Parameters:
+    ///   - as: decodable type
+    ///   - source: FirestoreSource
+    /// - Returns: Observable of decodable type
+    func decodable<T: Decodable>(as: T.Type, source: FirestoreSource = .default) -> Observable<T> {
+        document(source: source)
+            .map { try $0.data(as: T.self) }
+    }
+
+    /// set encodable data to given document reference
+    /// - Parameter data: encodable type
+    /// - Returns: Single whether set data is fail or success
+    func setData<T: Encodable>(_ data: T) -> Single<Void> {
+        Single.create { single -> Disposable in
+            do {
+                try base.setData(from: data) { error in
+                    if let error {
+                        single(.failure(error))
+                        return
+                    }
+                    single(.success(()))
+                }
+            } catch {
+                single(.failure(error))
+            }
+            return Disposables.create()
+        }
+    }
+
+    /// delete document
+    /// - Returns: Single whether deletion is fail or success
+    func deleteDocument() -> Single<Void> {
+        Single.create { single -> Disposable in
+            base.delete { error in
+                if let error {
+                    single(.failure(error))
+                    return
+                }
+                single(.success(()))
+            }
+            return Disposables.create()
+        }
+    }
+}


### PR DESCRIPTION
## Close Issues
🔒 Related to #6 

## 작업 내용 (Content)
- Firestore RxSwift Extension 추가했습니다.

## Review points
- Extension 폴더의 Firestore Extension 만 리뷰하면 될 것 같습니다.
- 일단 Rx Extension 을 추가하는 방법은 너무나 유명하니 아래 레퍼런스 탭을 참고해주세요.

```swift
func document(source: FirestoreSource = .default) -> Observable<DocumentSnapshot> {
      Observable.create { observer in
          base.getDocument(source: source) { snapshot, error in
              guard error == nil else {
                  observer.onError(error!)
                  return
              }
              guard let snapshot, snapshot.exists else {
                  observer.onError(RxFirestoreError.documentIsNotExist)
                  return
              }
              observer.onNext(snapshot)
              observer.onCompleted()
          }
          return Disposables.create()
      }
  }
```

- 기존 completion handler 를 사용하는 API 를, 위와 같이 Observable 로 바꿀 수 있습니다. (여기서 중요한 것은 꼭!! Observable 의 라이프 사이클에서 onComplete 혹은 onError 를 호출해서 Observable stream 을 종료해주어야 한다는 것입니다.
- 보통 Document Reference 에서 작업이 시작되기 때문에, Base 클래스를 DocumentReference 로 지정했습니다.

```swift
firestore.collection("TestCollection").document("document")
.getDocument  {
// completion handler
}

를

firestore.collection("TestCollection").document("document")
.document()
.subscribe.... //rx subscribe code
```

로 사용할 수 있습니다.

## 기타 사항 (Etc)
- 더 많은 Rx Extension 이 필요할 것 같은데, 이건 개발하면서 필요에 의해 추가하면 좋을 것 같아요.

## References (Optional)
- https://zeddios.tistory.com/1250
