### PR TITLE
feat: KaKao Login, Logout, unLink testUI 작성

### DIFF
--- a/Gom4ziz/.swiftlint.yml
+++ b/Gom4ziz/.swiftlint.yml
@@ -1,5 +1,6 @@
 disabled_rules:
   - identifier_name
+  - trailing_whitespace
 
 excluded:
 

--- a/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
+++ b/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
@@ -49,6 +49,9 @@
 		E63C75642909171100133C9E /* AppleLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C75632909171100133C9E /* AppleLoginManager.swift */; };
 		E6F4878B290982AC00037CF9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */; };
 		CCBFB77129090E3500173FD7 /* KakaoLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBFB77029090E3500173FD7 /* KakaoLoginViewModel.swift */; };
+		CC381332290A6B86009DD5F3 /* LoginManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC381331290A6B86009DD5F3 /* LoginManagerProtocol.swift */; };
+		CC381334290A6B96009DD5F3 /* KakaoLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC381333290A6B96009DD5F3 /* KakaoLoginManager.swift */; };
+		CCBFB77129090E3500173FD7 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBFB77029090E3500173FD7 /* LoginViewModel.swift */; };
 		CCF71D1D2907CFED00C66C55 /* KakaoLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */; };
 		CCF71D1F2907CFF900C66C55 /* KakaoLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */; };
 		CCF71D212907D02600C66C55 /* RxKakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = CCF71D202907D02600C66C55 /* RxKakaoSDKAuth */; };
@@ -104,6 +107,9 @@
 		E63C75652909415900133C9E /* Gom4ziz.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Gom4ziz.entitlements; sourceTree = "<group>"; };
 		E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		CCBFB77029090E3500173FD7 /* KakaoLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginViewModel.swift; sourceTree = "<group>"; };
+		CC381331290A6B86009DD5F3 /* LoginManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginManagerProtocol.swift; sourceTree = "<group>"; };
+		CC381333290A6B96009DD5F3 /* KakaoLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginManager.swift; sourceTree = "<group>"; };
+		CCBFB77029090E3500173FD7 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginView.swift; sourceTree = "<group>"; };
 		CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginViewController.swift; sourceTree = "<group>"; };
 		F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlansRoomListViewController.swift; path = Gom4ziz/Presenter/PlansRoomList/PlansRoomListViewController.swift; sourceTree = SOURCE_ROOT; };
@@ -349,7 +355,9 @@
 			children = (
 				CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */,
 				CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */,
-				CCBFB77029090E3500173FD7 /* KakaoLoginViewModel.swift */,
+				CCBFB77029090E3500173FD7 /* LoginViewModel.swift */,
+				CC381333290A6B96009DD5F3 /* KakaoLoginManager.swift */,
+				CC381331290A6B86009DD5F3 /* LoginManagerProtocol.swift */,
 			);
 			path = kakaoLoginTest;
 			sourceTree = "<group>";
@@ -540,10 +548,13 @@
 				F251F35F290549EF003B6690 /* PlansRoomRepository.swift in Sources */,
 				007EA01129062E1D000B8E31 /* Deeplink.swift in Sources */,
 				CCBFB77129090E3500173FD7 /* KakaoLoginViewModel.swift in Sources */,
+				CC381334290A6B96009DD5F3 /* KakaoLoginManager.swift in Sources */,
+				CCBFB77129090E3500173FD7 /* LoginViewModel.swift in Sources */,
 				CCF71D1F2907CFF900C66C55 /* KakaoLoginViewController.swift in Sources */,
 				002821F12901889000717E2C /* UserInfoRepository.swift in Sources */,
 				007EA01329062E4C000B8E31 /* DeeplinkParser.swift in Sources */,
 				000A53122904F31A00CEDACC /* ShareTestViewController.swift in Sources */,
+				CC381332290A6B86009DD5F3 /* LoginManagerProtocol.swift in Sources */,
 				0062EB7E2900222600B0A6AB /* SceneDelegate.swift in Sources */,
 				E63C75622909166900133C9E /* AppleTestViewController.swift in Sources */,
 				000A53082904D85700CEDACC /* APIKey.swift in Sources */,

--- a/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
+++ b/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		E63C75622909166900133C9E /* AppleTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C75612909166900133C9E /* AppleTestViewController.swift */; };
 		E63C75642909171100133C9E /* AppleLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C75632909171100133C9E /* AppleLoginManager.swift */; };
 		E6F4878B290982AC00037CF9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */; };
+		CCBFB77129090E3500173FD7 /* KakaoLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBFB77029090E3500173FD7 /* KakaoLoginViewModel.swift */; };
 		CCF71D1D2907CFED00C66C55 /* KakaoLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */; };
 		CCF71D1F2907CFF900C66C55 /* KakaoLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */; };
 		CCF71D212907D02600C66C55 /* RxKakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = CCF71D202907D02600C66C55 /* RxKakaoSDKAuth */; };
@@ -102,6 +103,7 @@
 		E63C75632909171100133C9E /* AppleLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginManager.swift; sourceTree = "<group>"; };
 		E63C75652909415900133C9E /* Gom4ziz.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Gom4ziz.entitlements; sourceTree = "<group>"; };
 		E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		CCBFB77029090E3500173FD7 /* KakaoLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginViewModel.swift; sourceTree = "<group>"; };
 		CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginView.swift; sourceTree = "<group>"; };
 		CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginViewController.swift; sourceTree = "<group>"; };
 		F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlansRoomListViewController.swift; path = Gom4ziz/Presenter/PlansRoomList/PlansRoomListViewController.swift; sourceTree = SOURCE_ROOT; };
@@ -347,6 +349,7 @@
 			children = (
 				CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */,
 				CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */,
+				CCBFB77029090E3500173FD7 /* KakaoLoginViewModel.swift */,
 			);
 			path = kakaoLoginTest;
 			sourceTree = "<group>";
@@ -536,6 +539,7 @@
 				002821F829022B2100717E2C /* UserInfoIdCache.swift in Sources */,
 				F251F35F290549EF003B6690 /* PlansRoomRepository.swift in Sources */,
 				007EA01129062E1D000B8E31 /* Deeplink.swift in Sources */,
+				CCBFB77129090E3500173FD7 /* KakaoLoginViewModel.swift in Sources */,
 				CCF71D1F2907CFF900C66C55 /* KakaoLoginViewController.swift in Sources */,
 				002821F12901889000717E2C /* UserInfoRepository.swift in Sources */,
 				007EA01329062E4C000B8E31 /* DeeplinkParser.swift in Sources */,
@@ -757,6 +761,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 953VJTV7TA;
+				DEVELOPMENT_TEAM = J7ZP3WYXRW;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Gom4ziz/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -791,6 +796,9 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 953VJTV7TA;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = J7ZP3WYXRW;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Gom4ziz/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
+++ b/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
@@ -48,6 +48,10 @@
 		E63C75622909166900133C9E /* AppleTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C75612909166900133C9E /* AppleTestViewController.swift */; };
 		E63C75642909171100133C9E /* AppleLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C75632909171100133C9E /* AppleLoginManager.swift */; };
 		E6F4878B290982AC00037CF9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */; };
+		CCF71D1D2907CFED00C66C55 /* KakaoLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */; };
+		CCF71D1F2907CFF900C66C55 /* KakaoLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */; };
+		CCF71D212907D02600C66C55 /* RxKakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = CCF71D202907D02600C66C55 /* RxKakaoSDKAuth */; };
+		CCF71D232907D03600C66C55 /* RxKakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = CCF71D222907D03600C66C55 /* RxKakaoSDKUser */; };
 		F251F35C2903EDA5003B6690 /* PlansRoomListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */; };
 		F251F35F290549EF003B6690 /* PlansRoomRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F35E290549EF003B6690 /* PlansRoomRepository.swift */; };
 		F251F36329055245003B6690 /* PlansRoomRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F36229055245003B6690 /* PlansRoomRepositoryTests.swift */; };
@@ -98,6 +102,8 @@
 		E63C75632909171100133C9E /* AppleLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginManager.swift; sourceTree = "<group>"; };
 		E63C75652909415900133C9E /* Gom4ziz.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Gom4ziz.entitlements; sourceTree = "<group>"; };
 		E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginView.swift; sourceTree = "<group>"; };
+		CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginViewController.swift; sourceTree = "<group>"; };
 		F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlansRoomListViewController.swift; path = Gom4ziz/Presenter/PlansRoomList/PlansRoomListViewController.swift; sourceTree = SOURCE_ROOT; };
 		F251F35E290549EF003B6690 /* PlansRoomRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlansRoomRepository.swift; sourceTree = "<group>"; };
 		F251F36229055245003B6690 /* PlansRoomRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlansRoomRepositoryTests.swift; sourceTree = "<group>"; };
@@ -123,7 +129,9 @@
 				000A52FF2904D43400CEDACC /* RxKakaoSDKCommon in Frameworks */,
 				001B1CA62901270C00F5C875 /* RxRelay in Frameworks */,
 				000A53012904D43400CEDACC /* RxKakaoSDKShare in Frameworks */,
+				CCF71D212907D02600C66C55 /* RxKakaoSDKAuth in Frameworks */,
 				001B1C8829010C4B00F5C875 /* FirebaseFirestore in Frameworks */,
+				CCF71D232907D03600C66C55 /* RxKakaoSDKUser in Frameworks */,
 				002821F62901932A00717E2C /* FirebaseFirestoreSwift in Frameworks */,
 				E68685D1290FAB3100674CC4 /* KeyChainWrapper in Frameworks */,
 			);
@@ -244,6 +252,7 @@
 			isa = PBXGroup;
 			children = (
 				E63C755E2909162600133C9E /* AppleLoginTest */,
+				CCF71D1B2907CFD500C66C55 /* kakaoLoginTest */,
 				000A53132904F32500CEDACC /* ShareTest */,
 				F251F35D2903EDD6003B6690 /* PlansRoomList */,
 			);
@@ -333,6 +342,13 @@
 				E63C75612909166900133C9E /* AppleTestViewController.swift */,
 			);
 			path = AppleLoginTest;
+		CCF71D1B2907CFD500C66C55 /* kakaoLoginTest */ = {
+			isa = PBXGroup;
+			children = (
+				CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */,
+				CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */,
+			);
+			path = kakaoLoginTest;
 			sourceTree = "<group>";
 		};
 		F251F35D2903EDD6003B6690 /* PlansRoomList */ = {
@@ -392,6 +408,8 @@
 				000A52FE2904D43400CEDACC /* RxKakaoSDKCommon */,
 				000A53002904D43400CEDACC /* RxKakaoSDKShare */,
 				E68685D0290FAB3100674CC4 /* KeyChainWrapper */,
+				CCF71D202907D02600C66C55 /* RxKakaoSDKAuth */,
+				CCF71D222907D03600C66C55 /* RxKakaoSDKUser */,
 			);
 			productName = Gom4ziz;
 			productReference = 0062EB782900222600B0A6AB /* Gom4ziz.app */;
@@ -511,12 +529,14 @@
 				000A53152904F33800CEDACC /* ShareTestView.swift in Sources */,
 				000A531C29050CB400CEDACC /* KakaoMessage.swift in Sources */,
 				000A531F29050DA700CEDACC /* SendInviteUsecase.swift in Sources */,
+				CCF71D1D2907CFED00C66C55 /* KakaoLoginView.swift in Sources */,
 				001B1C812900FE5B00F5C875 /* PlansRoom.swift in Sources */,
 				001B1C812900FE5B00F5C875 /* PlansRoom.swift in Sources */,
 				0062EB7C2900222600B0A6AB /* AppDelegate.swift in Sources */,
 				002821F829022B2100717E2C /* UserInfoIdCache.swift in Sources */,
 				F251F35F290549EF003B6690 /* PlansRoomRepository.swift in Sources */,
 				007EA01129062E1D000B8E31 /* Deeplink.swift in Sources */,
+				CCF71D1F2907CFF900C66C55 /* KakaoLoginViewController.swift in Sources */,
 				002821F12901889000717E2C /* UserInfoRepository.swift in Sources */,
 				007EA01329062E4C000B8E31 /* DeeplinkParser.swift in Sources */,
 				000A53122904F31A00CEDACC /* ShareTestViewController.swift in Sources */,
@@ -915,6 +935,15 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E68685CF290FAB3000674CC4 /* XCRemoteSwiftPackageReference "KeychainPackage" */;
 			productName = KeyChainWrapper;
+		CCF71D202907D02600C66C55 /* RxKakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 000A52FD2904D43400CEDACC /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
+			productName = RxKakaoSDKAuth;
+		};
+		CCF71D222907D03600C66C55 /* RxKakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 000A52FD2904D43400CEDACC /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
+			productName = RxKakaoSDKUser;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
+++ b/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
@@ -350,6 +350,8 @@
 				E63C75612909166900133C9E /* AppleTestViewController.swift */,
 			);
 			path = AppleLoginTest;
+			sourceTree = "<group>";
+		};
 		CCF71D1B2907CFD500C66C55 /* kakaoLoginTest */ = {
 			isa = PBXGroup;
 			children = (
@@ -547,7 +549,7 @@
 				002821F829022B2100717E2C /* UserInfoIdCache.swift in Sources */,
 				F251F35F290549EF003B6690 /* PlansRoomRepository.swift in Sources */,
 				007EA01129062E1D000B8E31 /* Deeplink.swift in Sources */,
-				CCBFB77129090E3500173FD7 /* KakaoLoginViewModel.swift in Sources */,
+				CCBFB77129090E3500173FD7 /* LoginViewModel.swift in Sources */,
 				CC381334290A6B96009DD5F3 /* KakaoLoginManager.swift in Sources */,
 				CCBFB77129090E3500173FD7 /* LoginViewModel.swift in Sources */,
 				CCF71D1F2907CFF900C66C55 /* KakaoLoginViewController.swift in Sources */,
@@ -764,7 +766,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Gom4ziz/Gom4ziz.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RS35G3C5;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -773,6 +775,7 @@
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 953VJTV7TA;
 				DEVELOPMENT_TEAM = J7ZP3WYXRW;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Gom4ziz/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -808,8 +811,9 @@
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 953VJTV7TA;
 				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = J7ZP3WYXRW;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Gom4ziz/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
+++ b/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
@@ -1,974 +1,967 @@
 // !$*UTF8*$!
 {
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 56;
-	objects = {
+    archiveVersion = 1;
+    classes = {
+    };
+    objectVersion = 56;
+    objects = {
 
 /* Begin PBXBuildFile section */
-		000A52FF2904D43400CEDACC /* RxKakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 000A52FE2904D43400CEDACC /* RxKakaoSDKCommon */; };
-		000A53012904D43400CEDACC /* RxKakaoSDKShare in Frameworks */ = {isa = PBXBuildFile; productRef = 000A53002904D43400CEDACC /* RxKakaoSDKShare */; };
-		000A53082904D85700CEDACC /* APIKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A53072904D85700CEDACC /* APIKey.swift */; };
-		000A530D2904E27400CEDACC /* KakaoMessageSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A530C2904E27400CEDACC /* KakaoMessageSender.swift */; };
-		000A53122904F31A00CEDACC /* ShareTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A53112904F31A00CEDACC /* ShareTestViewController.swift */; };
-		000A53152904F33800CEDACC /* ShareTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A53142904F33800CEDACC /* ShareTestView.swift */; };
-		000A53172904F38800CEDACC /* SwiftUI+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A53162904F38800CEDACC /* SwiftUI+UIKit.swift */; };
-		000A531C29050CB400CEDACC /* KakaoMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A531B29050CB400CEDACC /* KakaoMessage.swift */; };
-		000A531F29050DA700CEDACC /* SendInviteUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A531E29050DA700CEDACC /* SendInviteUsecase.swift */; };
-		001B1C7F2900FCC800F5C875 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001B1C7E2900FCC800F5C875 /* UserInfo.swift */; };
-		001B1C812900FE5B00F5C875 /* PlansRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001B1C802900FE5B00F5C875 /* PlansRoom.swift */; };
-		001B1C832901049400F5C875 /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001B1C822901049400F5C875 /* MockData.swift */; };
-		001B1C8629010C4B00F5C875 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 001B1C8529010C4B00F5C875 /* FirebaseAuth */; };
-		001B1C8829010C4B00F5C875 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 001B1C8729010C4B00F5C875 /* FirebaseFirestore */; };
-		001B1CA42901270C00F5C875 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 001B1CA32901270C00F5C875 /* RxCocoa */; };
-		001B1CA62901270C00F5C875 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = 001B1CA52901270C00F5C875 /* RxRelay */; };
-		001B1CA82901270C00F5C875 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 001B1CA72901270C00F5C875 /* RxSwift */; };
-		002821EF2901884100717E2C /* ProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821EE2901884100717E2C /* ProcessInfo.swift */; };
-		002821F12901889000717E2C /* UserInfoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821F02901889000717E2C /* UserInfoRepository.swift */; };
-		002821F329018E7700717E2C /* RxSwift+Firestore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821F229018E7700717E2C /* RxSwift+Firestore.swift */; };
-		002821F62901932A00717E2C /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 002821F52901932A00717E2C /* FirebaseFirestoreSwift */; };
-		002821F829022B2100717E2C /* UserInfoIdCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821F729022B2100717E2C /* UserInfoIdCache.swift */; };
-		003E5E5C2902D0FA004C597A /* RxBlocking in Frameworks */ = {isa = PBXBuildFile; productRef = 003E5E5B2902D0FA004C597A /* RxBlocking */; };
-		003E5E5E2902D0FA004C597A /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = 003E5E5D2902D0FA004C597A /* RxTest */; };
-		003E5E602902D1A6004C597A /* UserInfoRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003E5E5F2902D1A6004C597A /* UserInfoRepositoryTests.swift */; };
-		0062EB7C2900222600B0A6AB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0062EB7B2900222600B0A6AB /* AppDelegate.swift */; };
-		0062EB7E2900222600B0A6AB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0062EB7D2900222600B0A6AB /* SceneDelegate.swift */; };
-		0062EB832900222600B0A6AB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0062EB812900222600B0A6AB /* Main.storyboard */; };
-		0062EB852900222700B0A6AB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0062EB842900222700B0A6AB /* Assets.xcassets */; };
-		0062EB882900222700B0A6AB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0062EB862900222700B0A6AB /* LaunchScreen.storyboard */; };
-		0062EBAD290023A600B0A6AB /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 0062EBAC290023A600B0A6AB /* .swiftlint.yml */; };
-		007EA00D2906290B000B8E31 /* DeeplinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007EA00C2906290B000B8E31 /* DeeplinkHandler.swift */; };
-		007EA01129062E1D000B8E31 /* Deeplink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007EA01029062E1D000B8E31 /* Deeplink.swift */; };
-		007EA01329062E4C000B8E31 /* DeeplinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007EA01229062E4C000B8E31 /* DeeplinkParser.swift */; };
-		00953D162909008C0022D6A4 /* JoinPlansRoomUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00953D152909008C0022D6A4 /* JoinPlansRoomUsecase.swift */; };
-		00A12CED290651980024934C /* DeeplinkParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A12CEC290651980024934C /* DeeplinkParserTests.swift */; };
-		E68685D1290FAB3100674CC4 /* KeyChainWrapper in Frameworks */ = {isa = PBXBuildFile; productRef = E68685D0290FAB3100674CC4 /* KeyChainWrapper */; };
-		E63C75602909166200133C9E /* AppleTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C755F2909166200133C9E /* AppleTestView.swift */; };
-		E63C75622909166900133C9E /* AppleTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C75612909166900133C9E /* AppleTestViewController.swift */; };
-		E63C75642909171100133C9E /* AppleLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C75632909171100133C9E /* AppleLoginManager.swift */; };
-		E6F4878B290982AC00037CF9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */; };
-		CCBFB77129090E3500173FD7 /* KakaoLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBFB77029090E3500173FD7 /* KakaoLoginViewModel.swift */; };
-		CC381332290A6B86009DD5F3 /* LoginManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC381331290A6B86009DD5F3 /* LoginManagerProtocol.swift */; };
-		CC381334290A6B96009DD5F3 /* KakaoLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC381333290A6B96009DD5F3 /* KakaoLoginManager.swift */; };
-		CCBFB77129090E3500173FD7 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBFB77029090E3500173FD7 /* LoginViewModel.swift */; };
-		CCF71D1D2907CFED00C66C55 /* KakaoLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */; };
-		CCF71D1F2907CFF900C66C55 /* KakaoLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */; };
-		CCF71D212907D02600C66C55 /* RxKakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = CCF71D202907D02600C66C55 /* RxKakaoSDKAuth */; };
-		CCF71D232907D03600C66C55 /* RxKakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = CCF71D222907D03600C66C55 /* RxKakaoSDKUser */; };
-		F251F35C2903EDA5003B6690 /* PlansRoomListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */; };
-		F251F35F290549EF003B6690 /* PlansRoomRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F35E290549EF003B6690 /* PlansRoomRepository.swift */; };
-		F251F36329055245003B6690 /* PlansRoomRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F36229055245003B6690 /* PlansRoomRepositoryTests.swift */; };
+        000A52FF2904D43400CEDACC /* RxKakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 000A52FE2904D43400CEDACC /* RxKakaoSDKCommon */; };
+        000A53012904D43400CEDACC /* RxKakaoSDKShare in Frameworks */ = {isa = PBXBuildFile; productRef = 000A53002904D43400CEDACC /* RxKakaoSDKShare */; };
+        000A53082904D85700CEDACC /* APIKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A53072904D85700CEDACC /* APIKey.swift */; };
+        000A530D2904E27400CEDACC /* KakaoMessageSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A530C2904E27400CEDACC /* KakaoMessageSender.swift */; };
+        000A53122904F31A00CEDACC /* ShareTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A53112904F31A00CEDACC /* ShareTestViewController.swift */; };
+        000A53152904F33800CEDACC /* ShareTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A53142904F33800CEDACC /* ShareTestView.swift */; };
+        000A53172904F38800CEDACC /* SwiftUI+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A53162904F38800CEDACC /* SwiftUI+UIKit.swift */; };
+        000A531C29050CB400CEDACC /* KakaoMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A531B29050CB400CEDACC /* KakaoMessage.swift */; };
+        000A531F29050DA700CEDACC /* SendInviteUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000A531E29050DA700CEDACC /* SendInviteUsecase.swift */; };
+        001B1C7F2900FCC800F5C875 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001B1C7E2900FCC800F5C875 /* UserInfo.swift */; };
+        001B1C812900FE5B00F5C875 /* PlansRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001B1C802900FE5B00F5C875 /* PlansRoom.swift */; };
+        001B1C832901049400F5C875 /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001B1C822901049400F5C875 /* MockData.swift */; };
+        001B1C8629010C4B00F5C875 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 001B1C8529010C4B00F5C875 /* FirebaseAuth */; };
+        001B1C8829010C4B00F5C875 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 001B1C8729010C4B00F5C875 /* FirebaseFirestore */; };
+        001B1CA42901270C00F5C875 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 001B1CA32901270C00F5C875 /* RxCocoa */; };
+        001B1CA62901270C00F5C875 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = 001B1CA52901270C00F5C875 /* RxRelay */; };
+        001B1CA82901270C00F5C875 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 001B1CA72901270C00F5C875 /* RxSwift */; };
+        002821EF2901884100717E2C /* ProcessInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821EE2901884100717E2C /* ProcessInfo.swift */; };
+        002821F12901889000717E2C /* UserInfoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821F02901889000717E2C /* UserInfoRepository.swift */; };
+        002821F329018E7700717E2C /* RxSwift+Firestore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821F229018E7700717E2C /* RxSwift+Firestore.swift */; };
+        002821F62901932A00717E2C /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 002821F52901932A00717E2C /* FirebaseFirestoreSwift */; };
+        002821F829022B2100717E2C /* UserInfoIdCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821F729022B2100717E2C /* UserInfoIdCache.swift */; };
+        003E5E5C2902D0FA004C597A /* RxBlocking in Frameworks */ = {isa = PBXBuildFile; productRef = 003E5E5B2902D0FA004C597A /* RxBlocking */; };
+        003E5E5E2902D0FA004C597A /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = 003E5E5D2902D0FA004C597A /* RxTest */; };
+        003E5E602902D1A6004C597A /* UserInfoRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003E5E5F2902D1A6004C597A /* UserInfoRepositoryTests.swift */; };
+        0062EB7C2900222600B0A6AB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0062EB7B2900222600B0A6AB /* AppDelegate.swift */; };
+        0062EB7E2900222600B0A6AB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0062EB7D2900222600B0A6AB /* SceneDelegate.swift */; };
+        0062EB832900222600B0A6AB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0062EB812900222600B0A6AB /* Main.storyboard */; };
+        0062EB852900222700B0A6AB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0062EB842900222700B0A6AB /* Assets.xcassets */; };
+        0062EB882900222700B0A6AB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0062EB862900222700B0A6AB /* LaunchScreen.storyboard */; };
+        0062EBAD290023A600B0A6AB /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 0062EBAC290023A600B0A6AB /* .swiftlint.yml */; };
+        007EA00D2906290B000B8E31 /* DeeplinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007EA00C2906290B000B8E31 /* DeeplinkHandler.swift */; };
+        007EA01129062E1D000B8E31 /* Deeplink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007EA01029062E1D000B8E31 /* Deeplink.swift */; };
+        007EA01329062E4C000B8E31 /* DeeplinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007EA01229062E4C000B8E31 /* DeeplinkParser.swift */; };
+        00953D162909008C0022D6A4 /* JoinPlansRoomUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00953D152909008C0022D6A4 /* JoinPlansRoomUsecase.swift */; };
+        00A12CED290651980024934C /* DeeplinkParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A12CEC290651980024934C /* DeeplinkParserTests.swift */; };
+        CC381332290A6B86009DD5F3 /* LoginManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC381331290A6B86009DD5F3 /* LoginManagerProtocol.swift */; };
+        CC381334290A6B96009DD5F3 /* KakaoLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC381333290A6B96009DD5F3 /* KakaoLoginManager.swift */; };
+        CCBFB77129090E3500173FD7 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBFB77029090E3500173FD7 /* LoginViewModel.swift */; };
+        CCF71D1D2907CFED00C66C55 /* KakaoLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */; };
+        CCF71D1F2907CFF900C66C55 /* KakaoLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */; };
+        CCF71D212907D02600C66C55 /* RxKakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = CCF71D202907D02600C66C55 /* RxKakaoSDKAuth */; };
+        CCF71D232907D03600C66C55 /* RxKakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = CCF71D222907D03600C66C55 /* RxKakaoSDKUser */; };
+        E68685D1290FAB3100674CC4 /* KeyChainWrapper in Frameworks */ = {isa = PBXBuildFile; productRef = E68685D0290FAB3100674CC4 /* KeyChainWrapper */; };
+        E63C75602909166200133C9E /* AppleTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C755F2909166200133C9E /* AppleTestView.swift */; };
+        E63C75622909166900133C9E /* AppleTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C75612909166900133C9E /* AppleTestViewController.swift */; };
+        E63C75642909171100133C9E /* AppleLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C75632909171100133C9E /* AppleLoginManager.swift */; };
+        E6F4878B290982AC00037CF9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */; };
+        F251F35C2903EDA5003B6690 /* PlansRoomListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */; };
+        F251F35F290549EF003B6690 /* PlansRoomRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F35E290549EF003B6690 /* PlansRoomRepository.swift */; };
+        F251F36329055245003B6690 /* PlansRoomRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F36229055245003B6690 /* PlansRoomRepositoryTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		003E5E562902CF89004C597A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0062EB702900222600B0A6AB /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 0062EB772900222600B0A6AB;
-			remoteInfo = Gom4ziz;
-		};
+        003E5E562902CF89004C597A /* PBXContainerItemProxy */ = {
+            isa = PBXContainerItemProxy;
+            containerPortal = 0062EB702900222600B0A6AB /* Project object */;
+            proxyType = 1;
+            remoteGlobalIDString = 0062EB772900222600B0A6AB;
+            remoteInfo = Gom4ziz;
+        };
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		000A53072904D85700CEDACC /* APIKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKey.swift; sourceTree = "<group>"; };
-		000A530C2904E27400CEDACC /* KakaoMessageSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoMessageSender.swift; sourceTree = "<group>"; };
-		000A53112904F31A00CEDACC /* ShareTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTestViewController.swift; sourceTree = "<group>"; };
-		000A53142904F33800CEDACC /* ShareTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTestView.swift; sourceTree = "<group>"; };
-		000A53162904F38800CEDACC /* SwiftUI+UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUI+UIKit.swift"; sourceTree = "<group>"; };
-		000A531B29050CB400CEDACC /* KakaoMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoMessage.swift; sourceTree = "<group>"; };
-		000A531E29050DA700CEDACC /* SendInviteUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendInviteUsecase.swift; sourceTree = "<group>"; };
-		001B1C7E2900FCC800F5C875 /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
-		001B1C802900FE5B00F5C875 /* PlansRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlansRoom.swift; sourceTree = "<group>"; };
-		001B1C822901049400F5C875 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
-		002821EE2901884100717E2C /* ProcessInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfo.swift; sourceTree = "<group>"; };
-		002821F02901889000717E2C /* UserInfoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoRepository.swift; sourceTree = "<group>"; };
-		002821F229018E7700717E2C /* RxSwift+Firestore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RxSwift+Firestore.swift"; sourceTree = "<group>"; };
-		002821F729022B2100717E2C /* UserInfoIdCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoIdCache.swift; sourceTree = "<group>"; };
-		003E5E522902CF89004C597A /* Gom4zizTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Gom4zizTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		003E5E5F2902D1A6004C597A /* UserInfoRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoRepositoryTests.swift; sourceTree = "<group>"; };
-		0062EB782900222600B0A6AB /* Gom4ziz.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gom4ziz.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		0062EB7B2900222600B0A6AB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		0062EB7D2900222600B0A6AB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		0062EB822900222600B0A6AB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		0062EB842900222700B0A6AB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		0062EB872900222700B0A6AB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		0062EB892900222700B0A6AB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		0062EBAC290023A600B0A6AB /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
-		007EA00C2906290B000B8E31 /* DeeplinkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkHandler.swift; sourceTree = "<group>"; };
-		007EA01029062E1D000B8E31 /* Deeplink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deeplink.swift; sourceTree = "<group>"; };
-		007EA01229062E4C000B8E31 /* DeeplinkParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkParser.swift; sourceTree = "<group>"; };
-		00953D152909008C0022D6A4 /* JoinPlansRoomUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinPlansRoomUsecase.swift; sourceTree = "<group>"; };
-		00A12CEC290651980024934C /* DeeplinkParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkParserTests.swift; sourceTree = "<group>"; };
-		E63C755F2909166200133C9E /* AppleTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleTestView.swift; sourceTree = "<group>"; };
-		E63C75612909166900133C9E /* AppleTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleTestViewController.swift; sourceTree = "<group>"; };
-		E63C75632909171100133C9E /* AppleLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginManager.swift; sourceTree = "<group>"; };
-		E63C75652909415900133C9E /* Gom4ziz.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Gom4ziz.entitlements; sourceTree = "<group>"; };
-		E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
-		CCBFB77029090E3500173FD7 /* KakaoLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginViewModel.swift; sourceTree = "<group>"; };
-		CC381331290A6B86009DD5F3 /* LoginManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginManagerProtocol.swift; sourceTree = "<group>"; };
-		CC381333290A6B96009DD5F3 /* KakaoLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginManager.swift; sourceTree = "<group>"; };
-		CCBFB77029090E3500173FD7 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
-		CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginView.swift; sourceTree = "<group>"; };
-		CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginViewController.swift; sourceTree = "<group>"; };
-		F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlansRoomListViewController.swift; path = Gom4ziz/Presenter/PlansRoomList/PlansRoomListViewController.swift; sourceTree = SOURCE_ROOT; };
-		F251F35E290549EF003B6690 /* PlansRoomRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlansRoomRepository.swift; sourceTree = "<group>"; };
-		F251F36229055245003B6690 /* PlansRoomRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlansRoomRepositoryTests.swift; sourceTree = "<group>"; };
+        000A53072904D85700CEDACC /* APIKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKey.swift; sourceTree = "<group>"; };
+        000A530C2904E27400CEDACC /* KakaoMessageSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoMessageSender.swift; sourceTree = "<group>"; };
+        000A53112904F31A00CEDACC /* ShareTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTestViewController.swift; sourceTree = "<group>"; };
+        000A53142904F33800CEDACC /* ShareTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareTestView.swift; sourceTree = "<group>"; };
+        000A53162904F38800CEDACC /* SwiftUI+UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUI+UIKit.swift"; sourceTree = "<group>"; };
+        000A531B29050CB400CEDACC /* KakaoMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoMessage.swift; sourceTree = "<group>"; };
+        000A531E29050DA700CEDACC /* SendInviteUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendInviteUsecase.swift; sourceTree = "<group>"; };
+        001B1C7E2900FCC800F5C875 /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
+        001B1C802900FE5B00F5C875 /* PlansRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlansRoom.swift; sourceTree = "<group>"; };
+        001B1C822901049400F5C875 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
+        002821EE2901884100717E2C /* ProcessInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfo.swift; sourceTree = "<group>"; };
+        002821F02901889000717E2C /* UserInfoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoRepository.swift; sourceTree = "<group>"; };
+        002821F229018E7700717E2C /* RxSwift+Firestore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RxSwift+Firestore.swift"; sourceTree = "<group>"; };
+        002821F729022B2100717E2C /* UserInfoIdCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoIdCache.swift; sourceTree = "<group>"; };
+        003E5E522902CF89004C597A /* Gom4zizTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Gom4zizTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+        003E5E5F2902D1A6004C597A /* UserInfoRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoRepositoryTests.swift; sourceTree = "<group>"; };
+        0062EB782900222600B0A6AB /* Gom4ziz.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gom4ziz.app; sourceTree = BUILT_PRODUCTS_DIR; };
+        0062EB7B2900222600B0A6AB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+        0062EB7D2900222600B0A6AB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+        0062EB822900222600B0A6AB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+        0062EB842900222700B0A6AB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+        0062EB872900222700B0A6AB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+        0062EB892900222700B0A6AB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+        0062EBAC290023A600B0A6AB /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+        007EA00C2906290B000B8E31 /* DeeplinkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkHandler.swift; sourceTree = "<group>"; };
+        007EA01029062E1D000B8E31 /* Deeplink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deeplink.swift; sourceTree = "<group>"; };
+        007EA01229062E4C000B8E31 /* DeeplinkParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkParser.swift; sourceTree = "<group>"; };
+        00953D152909008C0022D6A4 /* JoinPlansRoomUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinPlansRoomUsecase.swift; sourceTree = "<group>"; };
+        00A12CEC290651980024934C /* DeeplinkParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkParserTests.swift; sourceTree = "<group>"; };
+        CC381331290A6B86009DD5F3 /* LoginManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginManagerProtocol.swift; sourceTree = "<group>"; };
+        CC381333290A6B96009DD5F3 /* KakaoLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginManager.swift; sourceTree = "<group>"; };
+        CCBFB77029090E3500173FD7 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+        CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginView.swift; sourceTree = "<group>"; };
+        CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginViewController.swift; sourceTree = "<group>"; };
+        E63C755F2909166200133C9E /* AppleTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleTestView.swift; sourceTree = "<group>"; };
+        E63C75612909166900133C9E /* AppleTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleTestViewController.swift; sourceTree = "<group>"; };
+        E63C75632909171100133C9E /* AppleLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginManager.swift; sourceTree = "<group>"; };
+        E63C75652909415900133C9E /* Gom4ziz.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Gom4ziz.entitlements; sourceTree = "<group>"; };
+        E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+        F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlansRoomListViewController.swift; path = Gom4ziz/Presenter/PlansRoomList/PlansRoomListViewController.swift; sourceTree = SOURCE_ROOT; };
+        F251F35E290549EF003B6690 /* PlansRoomRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlansRoomRepository.swift; sourceTree = "<group>"; };
+        F251F36229055245003B6690 /* PlansRoomRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlansRoomRepositoryTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		003E5E4F2902CF89004C597A /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				003E5E5E2902D0FA004C597A /* RxTest in Frameworks */,
-				003E5E5C2902D0FA004C597A /* RxBlocking in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		0062EB752900222600B0A6AB /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				001B1CA42901270C00F5C875 /* RxCocoa in Frameworks */,
-				001B1C8629010C4B00F5C875 /* FirebaseAuth in Frameworks */,
-				001B1CA82901270C00F5C875 /* RxSwift in Frameworks */,
-				000A52FF2904D43400CEDACC /* RxKakaoSDKCommon in Frameworks */,
-				001B1CA62901270C00F5C875 /* RxRelay in Frameworks */,
-				000A53012904D43400CEDACC /* RxKakaoSDKShare in Frameworks */,
-				CCF71D212907D02600C66C55 /* RxKakaoSDKAuth in Frameworks */,
-				001B1C8829010C4B00F5C875 /* FirebaseFirestore in Frameworks */,
-				CCF71D232907D03600C66C55 /* RxKakaoSDKUser in Frameworks */,
-				002821F62901932A00717E2C /* FirebaseFirestoreSwift in Frameworks */,
-				E68685D1290FAB3100674CC4 /* KeyChainWrapper in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+        003E5E4F2902CF89004C597A /* Frameworks */ = {
+            isa = PBXFrameworksBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                003E5E5E2902D0FA004C597A /* RxTest in Frameworks */,
+                003E5E5C2902D0FA004C597A /* RxBlocking in Frameworks */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        0062EB752900222600B0A6AB /* Frameworks */ = {
+            isa = PBXFrameworksBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                001B1CA42901270C00F5C875 /* RxCocoa in Frameworks */,
+                001B1C8629010C4B00F5C875 /* FirebaseAuth in Frameworks */,
+                001B1CA82901270C00F5C875 /* RxSwift in Frameworks */,
+                000A52FF2904D43400CEDACC /* RxKakaoSDKCommon in Frameworks */,
+                001B1CA62901270C00F5C875 /* RxRelay in Frameworks */,
+                000A53012904D43400CEDACC /* RxKakaoSDKShare in Frameworks */,
+                CCF71D212907D02600C66C55 /* RxKakaoSDKAuth in Frameworks */,
+                001B1C8829010C4B00F5C875 /* FirebaseFirestore in Frameworks */,
+                CCF71D232907D03600C66C55 /* RxKakaoSDKUser in Frameworks */,
+                002821F62901932A00717E2C /* FirebaseFirestoreSwift in Frameworks */,
+                E68685D1290FAB3100674CC4 /* KeyChainWrapper in Frameworks */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		000A53022904D7E900CEDACC /* Secret */ = {
-			isa = PBXGroup;
-			children = (
-				000A53072904D85700CEDACC /* APIKey.swift */,
-			);
-			path = Secret;
-			sourceTree = "<group>";
-		};
-		000A53092904DF8900CEDACC /* Service */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Service;
-			sourceTree = "<group>";
-		};
-		000A53132904F32500CEDACC /* ShareTest */ = {
-			isa = PBXGroup;
-			children = (
-				000A53112904F31A00CEDACC /* ShareTestViewController.swift */,
-				000A53142904F33800CEDACC /* ShareTestView.swift */,
-			);
-			path = ShareTest;
-			sourceTree = "<group>";
-		};
-		000A531A29050C9400CEDACC /* MessageSender */ = {
-			isa = PBXGroup;
-			children = (
-				000A530C2904E27400CEDACC /* KakaoMessageSender.swift */,
-				000A531B29050CB400CEDACC /* KakaoMessage.swift */,
-			);
-			path = MessageSender;
-			sourceTree = "<group>";
-		};
-		000A531D29050D9500CEDACC /* Usecase */ = {
-			isa = PBXGroup;
-			children = (
-				000A531E29050DA700CEDACC /* SendInviteUsecase.swift */,
-				00953D152909008C0022D6A4 /* JoinPlansRoomUsecase.swift */,
-			);
-			path = Usecase;
-			sourceTree = "<group>";
-		};
-		001B1C7D2900FCBE00F5C875 /* Model */ = {
-			isa = PBXGroup;
-			children = (
-				001B1C7E2900FCC800F5C875 /* UserInfo.swift */,
-				001B1C802900FE5B00F5C875 /* PlansRoom.swift */,
-				001B1C822901049400F5C875 /* MockData.swift */,
-				E63C75632909171100133C9E /* AppleLoginManager.swift */,
-			);
-			path = Model;
-			sourceTree = "<group>";
-		};
-		002821F42901932A00717E2C /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		003E5E532902CF89004C597A /* Gom4zizTests */ = {
-			isa = PBXGroup;
-			children = (
-				00A12CE9290651850024934C /* System */,
-				003E5E5F2902D1A6004C597A /* UserInfoRepositoryTests.swift */,
-				F251F36229055245003B6690 /* PlansRoomRepositoryTests.swift */,
-			);
-			path = Gom4zizTests;
-			sourceTree = "<group>";
-		};
-		0062EB6F2900222600B0A6AB = {
-			isa = PBXGroup;
-			children = (
-				E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */,
-				0062EBAC290023A600B0A6AB /* .swiftlint.yml */,
-				0062EB7A2900222600B0A6AB /* Gom4ziz */,
-				003E5E532902CF89004C597A /* Gom4zizTests */,
-				0062EB792900222600B0A6AB /* Products */,
-				002821F42901932A00717E2C /* Frameworks */,
-			);
-			sourceTree = "<group>";
-		};
-		0062EB792900222600B0A6AB /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				0062EB782900222600B0A6AB /* Gom4ziz.app */,
-				003E5E522902CF89004C597A /* Gom4zizTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		0062EB7A2900222600B0A6AB /* Gom4ziz */ = {
-			isa = PBXGroup;
-			children = (
-				E63C75652909415900133C9E /* Gom4ziz.entitlements */,
-				000A53092904DF8900CEDACC /* Service */,
-				000A53022904D7E900CEDACC /* Secret */,
-				0062EBB0290024FB00B0A6AB /* Data */,
-				0062EBAF290024F900B0A6AB /* Domain */,
-				0062EBB12900254600B0A6AB /* Extension */,
-				0062EBAE290024F500B0A6AB /* Presenter */,
-				0062EBB52900255700B0A6AB /* Resources */,
-				0062EBB42900255300B0A6AB /* System */,
-				0062EBB32900254E00B0A6AB /* Utility */,
-			);
-			path = Gom4ziz;
-			sourceTree = "<group>";
-		};
-		0062EBAE290024F500B0A6AB /* Presenter */ = {
-			isa = PBXGroup;
-			children = (
-				E63C755E2909162600133C9E /* AppleLoginTest */,
-				CCF71D1B2907CFD500C66C55 /* kakaoLoginTest */,
-				000A53132904F32500CEDACC /* ShareTest */,
-				F251F35D2903EDD6003B6690 /* PlansRoomList */,
-			);
-			path = Presenter;
-			sourceTree = "<group>";
-		};
-		0062EBAF290024F900B0A6AB /* Domain */ = {
-			isa = PBXGroup;
-			children = (
-				000A531D29050D9500CEDACC /* Usecase */,
-				000A531A29050C9400CEDACC /* MessageSender */,
-				001B1C7D2900FCBE00F5C875 /* Model */,
-			);
-			path = Domain;
-			sourceTree = "<group>";
-		};
-		0062EBB0290024FB00B0A6AB /* Data */ = {
-			isa = PBXGroup;
-			children = (
-				002821F02901889000717E2C /* UserInfoRepository.swift */,
-				002821F729022B2100717E2C /* UserInfoIdCache.swift */,
-				F251F35E290549EF003B6690 /* PlansRoomRepository.swift */,
-			);
-			path = Data;
-			sourceTree = "<group>";
-		};
-		0062EBB12900254600B0A6AB /* Extension */ = {
-			isa = PBXGroup;
-			children = (
-				002821EE2901884100717E2C /* ProcessInfo.swift */,
-				002821F229018E7700717E2C /* RxSwift+Firestore.swift */,
-				000A53162904F38800CEDACC /* SwiftUI+UIKit.swift */,
-			);
-			path = Extension;
-			sourceTree = "<group>";
-		};
-		0062EBB32900254E00B0A6AB /* Utility */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Utility;
-			sourceTree = "<group>";
-		};
-		0062EBB42900255300B0A6AB /* System */ = {
-			isa = PBXGroup;
-			children = (
-				007EA00F29062E15000B8E31 /* Deeplink */,
-				0062EB7B2900222600B0A6AB /* AppDelegate.swift */,
-				0062EB7D2900222600B0A6AB /* SceneDelegate.swift */,
-			);
-			path = System;
-			sourceTree = "<group>";
-		};
-		0062EBB52900255700B0A6AB /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				0062EB842900222700B0A6AB /* Assets.xcassets */,
-				0062EB892900222700B0A6AB /* Info.plist */,
-				0062EB862900222700B0A6AB /* LaunchScreen.storyboard */,
-				0062EB812900222600B0A6AB /* Main.storyboard */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		007EA00F29062E15000B8E31 /* Deeplink */ = {
-			isa = PBXGroup;
-			children = (
-				007EA00C2906290B000B8E31 /* DeeplinkHandler.swift */,
-				007EA01029062E1D000B8E31 /* Deeplink.swift */,
-				007EA01229062E4C000B8E31 /* DeeplinkParser.swift */,
-			);
-			path = Deeplink;
-			sourceTree = "<group>";
-		};
-		00A12CE9290651850024934C /* System */ = {
-			isa = PBXGroup;
-			children = (
-				00A12CEC290651980024934C /* DeeplinkParserTests.swift */,
-			);
-			path = System;
+        000A53022904D7E900CEDACC /* Secret */ = {
+            isa = PBXGroup;
+            children = (
+                000A53072904D85700CEDACC /* APIKey.swift */,
+            );
+            path = Secret;
             sourceTree = "<group>";
         };
-		E63C755E2909162600133C9E /* AppleLoginTest */ = {
-			isa = PBXGroup;
-			children = (
-				E63C755F2909166200133C9E /* AppleTestView.swift */,
-				E63C75612909166900133C9E /* AppleTestViewController.swift */,
-			);
-			path = AppleLoginTest;
-			sourceTree = "<group>";
-		};
-		CCF71D1B2907CFD500C66C55 /* kakaoLoginTest */ = {
-			isa = PBXGroup;
-			children = (
-				CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */,
-				CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */,
-				CCBFB77029090E3500173FD7 /* LoginViewModel.swift */,
-				CC381333290A6B96009DD5F3 /* KakaoLoginManager.swift */,
-				CC381331290A6B86009DD5F3 /* LoginManagerProtocol.swift */,
-			);
-			path = kakaoLoginTest;
-			sourceTree = "<group>";
-		};
-		F251F35D2903EDD6003B6690 /* PlansRoomList */ = {
-			isa = PBXGroup;
-			children = (
-				F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */,
-			);
-			path = PlansRoomList;
-			sourceTree = "<group>";
-		};
+        000A53092904DF8900CEDACC /* Service */ = {
+            isa = PBXGroup;
+            children = (
+            );
+            path = Service;
+            sourceTree = "<group>";
+        };
+        000A53132904F32500CEDACC /* ShareTest */ = {
+            isa = PBXGroup;
+            children = (
+                000A53112904F31A00CEDACC /* ShareTestViewController.swift */,
+                000A53142904F33800CEDACC /* ShareTestView.swift */,
+            );
+            path = ShareTest;
+            sourceTree = "<group>";
+        };
+        000A531A29050C9400CEDACC /* MessageSender */ = {
+            isa = PBXGroup;
+            children = (
+                000A530C2904E27400CEDACC /* KakaoMessageSender.swift */,
+                000A531B29050CB400CEDACC /* KakaoMessage.swift */,
+            );
+            path = MessageSender;
+            sourceTree = "<group>";
+        };
+        000A531D29050D9500CEDACC /* Usecase */ = {
+            isa = PBXGroup;
+            children = (
+                000A531E29050DA700CEDACC /* SendInviteUsecase.swift */,
+                00953D152909008C0022D6A4 /* JoinPlansRoomUsecase.swift */,
+            );
+            path = Usecase;
+            sourceTree = "<group>";
+        };
+        001B1C7D2900FCBE00F5C875 /* Model */ = {
+            isa = PBXGroup;
+            children = (
+                001B1C7E2900FCC800F5C875 /* UserInfo.swift */,
+                001B1C802900FE5B00F5C875 /* PlansRoom.swift */,
+                001B1C822901049400F5C875 /* MockData.swift */,
+                E63C75632909171100133C9E /* AppleLoginManager.swift */,
+            );
+            path = Model;
+            sourceTree = "<group>";
+        };
+        002821F42901932A00717E2C /* Frameworks */ = {
+            isa = PBXGroup;
+            children = (
+            );
+            name = Frameworks;
+            sourceTree = "<group>";
+        };
+        003E5E532902CF89004C597A /* Gom4zizTests */ = {
+            isa = PBXGroup;
+            children = (
+                00A12CE9290651850024934C /* System */,
+                003E5E5F2902D1A6004C597A /* UserInfoRepositoryTests.swift */,
+                F251F36229055245003B6690 /* PlansRoomRepositoryTests.swift */,
+            );
+            path = Gom4zizTests;
+            sourceTree = "<group>";
+        };
+        0062EB6F2900222600B0A6AB = {
+            isa = PBXGroup;
+            children = (
+                E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */,
+                0062EBAC290023A600B0A6AB /* .swiftlint.yml */,
+                0062EB7A2900222600B0A6AB /* Gom4ziz */,
+                003E5E532902CF89004C597A /* Gom4zizTests */,
+                0062EB792900222600B0A6AB /* Products */,
+                002821F42901932A00717E2C /* Frameworks */,
+            );
+            sourceTree = "<group>";
+        };
+        0062EB792900222600B0A6AB /* Products */ = {
+            isa = PBXGroup;
+            children = (
+                0062EB782900222600B0A6AB /* Gom4ziz.app */,
+                003E5E522902CF89004C597A /* Gom4zizTests.xctest */,
+            );
+            name = Products;
+            sourceTree = "<group>";
+        };
+        0062EB7A2900222600B0A6AB /* Gom4ziz */ = {
+            isa = PBXGroup;
+            children = (
+                E63C75652909415900133C9E /* Gom4ziz.entitlements */,
+                000A53092904DF8900CEDACC /* Service */,
+                000A53022904D7E900CEDACC /* Secret */,
+                0062EBB0290024FB00B0A6AB /* Data */,
+                0062EBAF290024F900B0A6AB /* Domain */,
+                0062EBB12900254600B0A6AB /* Extension */,
+                0062EBAE290024F500B0A6AB /* Presenter */,
+                0062EBB52900255700B0A6AB /* Resources */,
+                0062EBB42900255300B0A6AB /* System */,
+                0062EBB32900254E00B0A6AB /* Utility */,
+            );
+            path = Gom4ziz;
+            sourceTree = "<group>";
+        };
+        0062EBAE290024F500B0A6AB /* Presenter */ = {
+            isa = PBXGroup;
+            children = (
+                CCF71D1B2907CFD500C66C55 /* kakaoLoginTest */,
+                E63C755E2909162600133C9E /* AppleLoginTest */,
+                000A53132904F32500CEDACC /* ShareTest */,
+                F251F35D2903EDD6003B6690 /* PlansRoomList */,
+            );
+            path = Presenter;
+            sourceTree = "<group>";
+        };
+        0062EBAF290024F900B0A6AB /* Domain */ = {
+            isa = PBXGroup;
+            children = (
+                000A531D29050D9500CEDACC /* Usecase */,
+                000A531A29050C9400CEDACC /* MessageSender */,
+                001B1C7D2900FCBE00F5C875 /* Model */,
+            );
+            path = Domain;
+            sourceTree = "<group>";
+        };
+        0062EBB0290024FB00B0A6AB /* Data */ = {
+            isa = PBXGroup;
+            children = (
+                002821F02901889000717E2C /* UserInfoRepository.swift */,
+                002821F729022B2100717E2C /* UserInfoIdCache.swift */,
+                F251F35E290549EF003B6690 /* PlansRoomRepository.swift */,
+            );
+            path = Data;
+            sourceTree = "<group>";
+        };
+        0062EBB12900254600B0A6AB /* Extension */ = {
+            isa = PBXGroup;
+            children = (
+                002821EE2901884100717E2C /* ProcessInfo.swift */,
+                002821F229018E7700717E2C /* RxSwift+Firestore.swift */,
+                000A53162904F38800CEDACC /* SwiftUI+UIKit.swift */,
+            );
+            path = Extension;
+            sourceTree = "<group>";
+        };
+        0062EBB32900254E00B0A6AB /* Utility */ = {
+            isa = PBXGroup;
+            children = (
+            );
+            path = Utility;
+            sourceTree = "<group>";
+        };
+        0062EBB42900255300B0A6AB /* System */ = {
+            isa = PBXGroup;
+            children = (
+                007EA00F29062E15000B8E31 /* Deeplink */,
+                0062EB7B2900222600B0A6AB /* AppDelegate.swift */,
+                0062EB7D2900222600B0A6AB /* SceneDelegate.swift */,
+            );
+            path = System;
+            sourceTree = "<group>";
+        };
+        0062EBB52900255700B0A6AB /* Resources */ = {
+            isa = PBXGroup;
+            children = (
+                0062EB842900222700B0A6AB /* Assets.xcassets */,
+                0062EB892900222700B0A6AB /* Info.plist */,
+                0062EB862900222700B0A6AB /* LaunchScreen.storyboard */,
+                0062EB812900222600B0A6AB /* Main.storyboard */,
+            );
+            path = Resources;
+            sourceTree = "<group>";
+        };
+        007EA00F29062E15000B8E31 /* Deeplink */ = {
+            isa = PBXGroup;
+            children = (
+                007EA00C2906290B000B8E31 /* DeeplinkHandler.swift */,
+                007EA01029062E1D000B8E31 /* Deeplink.swift */,
+                007EA01229062E4C000B8E31 /* DeeplinkParser.swift */,
+            );
+            path = Deeplink;
+            sourceTree = "<group>";
+        };
+        00A12CE9290651850024934C /* System */ = {
+            isa = PBXGroup;
+            children = (
+                00A12CEC290651980024934C /* DeeplinkParserTests.swift */,
+            );
+            path = System;
+      sourceTree = "<group>";
+    };
+        E63C755E2909162600133C9E /* AppleLoginTest */ = {
+            isa = PBXGroup;
+            children = (
+                E63C755F2909166200133C9E /* AppleTestView.swift */,
+                E63C75612909166900133C9E /* AppleTestViewController.swift */,
+            );
+            path = AppleLoginTest;
+            sourceTree = "<group>";
+        };
+        CCF71D1B2907CFD500C66C55 /* kakaoLoginTest */ = {
+            isa = PBXGroup;
+            children = (
+                CCF71D1C2907CFED00C66C55 /* KakaoLoginView.swift */,
+                CCF71D1E2907CFF900C66C55 /* KakaoLoginViewController.swift */,
+                CCBFB77029090E3500173FD7 /* LoginViewModel.swift */,
+                CC381333290A6B96009DD5F3 /* KakaoLoginManager.swift */,
+                CC381331290A6B86009DD5F3 /* LoginManagerProtocol.swift */,
+            );
+            path = kakaoLoginTest;
+            sourceTree = "<group>";
+        };
+        F251F35D2903EDD6003B6690 /* PlansRoomList */ = {
+            isa = PBXGroup;
+            children = (
+                F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */,
+            );
+            path = PlansRoomList;
+            sourceTree = "<group>";
+        };
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		003E5E512902CF89004C597A /* Gom4zizTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 003E5E582902CF89004C597A /* Build configuration list for PBXNativeTarget "Gom4zizTests" */;
-			buildPhases = (
-				003E5E4E2902CF89004C597A /* Sources */,
-				003E5E4F2902CF89004C597A /* Frameworks */,
-				003E5E502902CF89004C597A /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				003E5E572902CF89004C597A /* PBXTargetDependency */,
-			);
-			name = Gom4zizTests;
-			packageProductDependencies = (
-				003E5E5B2902D0FA004C597A /* RxBlocking */,
-				003E5E5D2902D0FA004C597A /* RxTest */,
-			);
-			productName = Gom4zizTests;
-			productReference = 003E5E522902CF89004C597A /* Gom4zizTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		0062EB772900222600B0A6AB /* Gom4ziz */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 0062EBA22900222700B0A6AB /* Build configuration list for PBXNativeTarget "Gom4ziz" */;
-			buildPhases = (
-				0062EBAB2900234700B0A6AB /* Swiftlint script */,
-				0062EB742900222600B0A6AB /* Sources */,
-				0062EB752900222600B0A6AB /* Frameworks */,
-				0062EB762900222600B0A6AB /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Gom4ziz;
-			packageProductDependencies = (
-				001B1C8529010C4B00F5C875 /* FirebaseAuth */,
-				001B1C8729010C4B00F5C875 /* FirebaseFirestore */,
-				001B1CA32901270C00F5C875 /* RxCocoa */,
-				001B1CA52901270C00F5C875 /* RxRelay */,
-				001B1CA72901270C00F5C875 /* RxSwift */,
-				002821F52901932A00717E2C /* FirebaseFirestoreSwift */,
-				000A52FE2904D43400CEDACC /* RxKakaoSDKCommon */,
-				000A53002904D43400CEDACC /* RxKakaoSDKShare */,
-				E68685D0290FAB3100674CC4 /* KeyChainWrapper */,
-				CCF71D202907D02600C66C55 /* RxKakaoSDKAuth */,
-				CCF71D222907D03600C66C55 /* RxKakaoSDKUser */,
-			);
-			productName = Gom4ziz;
-			productReference = 0062EB782900222600B0A6AB /* Gom4ziz.app */;
-			productType = "com.apple.product-type.application";
-		};
+        003E5E512902CF89004C597A /* Gom4zizTests */ = {
+            isa = PBXNativeTarget;
+            buildConfigurationList = 003E5E582902CF89004C597A /* Build configuration list for PBXNativeTarget "Gom4zizTests" */;
+            buildPhases = (
+                003E5E4E2902CF89004C597A /* Sources */,
+                003E5E4F2902CF89004C597A /* Frameworks */,
+                003E5E502902CF89004C597A /* Resources */,
+            );
+            buildRules = (
+            );
+            dependencies = (
+                003E5E572902CF89004C597A /* PBXTargetDependency */,
+            );
+            name = Gom4zizTests;
+            packageProductDependencies = (
+                003E5E5B2902D0FA004C597A /* RxBlocking */,
+                003E5E5D2902D0FA004C597A /* RxTest */,
+            );
+            productName = Gom4zizTests;
+            productReference = 003E5E522902CF89004C597A /* Gom4zizTests.xctest */;
+            productType = "com.apple.product-type.bundle.unit-test";
+        };
+        0062EB772900222600B0A6AB /* Gom4ziz */ = {
+            isa = PBXNativeTarget;
+            buildConfigurationList = 0062EBA22900222700B0A6AB /* Build configuration list for PBXNativeTarget "Gom4ziz" */;
+            buildPhases = (
+                0062EBAB2900234700B0A6AB /* Swiftlint script */,
+                0062EB742900222600B0A6AB /* Sources */,
+                0062EB752900222600B0A6AB /* Frameworks */,
+                0062EB762900222600B0A6AB /* Resources */,
+            );
+            buildRules = (
+            );
+            dependencies = (
+            );
+            name = Gom4ziz;
+            packageProductDependencies = (
+                001B1C8529010C4B00F5C875 /* FirebaseAuth */,
+                001B1C8729010C4B00F5C875 /* FirebaseFirestore */,
+                001B1CA32901270C00F5C875 /* RxCocoa */,
+                001B1CA52901270C00F5C875 /* RxRelay */,
+                001B1CA72901270C00F5C875 /* RxSwift */,
+                002821F52901932A00717E2C /* FirebaseFirestoreSwift */,
+                000A52FE2904D43400CEDACC /* RxKakaoSDKCommon */,
+                000A53002904D43400CEDACC /* RxKakaoSDKShare */,
+                CCF71D202907D02600C66C55 /* RxKakaoSDKAuth */,
+                CCF71D222907D03600C66C55 /* RxKakaoSDKUser */,
+                E68685D0290FAB3100674CC4 /* KeyChainWrapper */,
+            );
+            productName = Gom4ziz;
+            productReference = 0062EB782900222600B0A6AB /* Gom4ziz.app */;
+            productType = "com.apple.product-type.application";
+        };
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		0062EB702900222600B0A6AB /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1400;
-				LastUpgradeCheck = 1400;
-				TargetAttributes = {
-					003E5E512902CF89004C597A = {
-						CreatedOnToolsVersion = 14.0.1;
-						LastSwiftMigration = 1400;
-						TestTargetID = 0062EB772900222600B0A6AB;
-					};
-					0062EB772900222600B0A6AB = {
-						CreatedOnToolsVersion = 14.0.1;
-					};
-				};
-			};
-			buildConfigurationList = 0062EB732900222600B0A6AB /* Build configuration list for PBXProject "Gom4ziz" */;
-			compatibilityVersion = "Xcode 14.0";
-			developmentRegion = en;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-				Base,
-			);
-			mainGroup = 0062EB6F2900222600B0A6AB;
-			packageReferences = (
-				001B1C8429010C4B00F5C875 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
-				001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */,
-				000A52FD2904D43400CEDACC /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */,
-				E68685CF290FAB3000674CC4 /* XCRemoteSwiftPackageReference "KeychainPackage" */,
-			);
-			productRefGroup = 0062EB792900222600B0A6AB /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				0062EB772900222600B0A6AB /* Gom4ziz */,
-				003E5E512902CF89004C597A /* Gom4zizTests */,
-			);
-		};
+        0062EB702900222600B0A6AB /* Project object */ = {
+            isa = PBXProject;
+            attributes = {
+                BuildIndependentTargetsInParallel = 1;
+                LastSwiftUpdateCheck = 1400;
+                LastUpgradeCheck = 1400;
+                TargetAttributes = {
+                    003E5E512902CF89004C597A = {
+                        CreatedOnToolsVersion = 14.0.1;
+                        LastSwiftMigration = 1400;
+                        TestTargetID = 0062EB772900222600B0A6AB;
+                    };
+                    0062EB772900222600B0A6AB = {
+                        CreatedOnToolsVersion = 14.0.1;
+                    };
+                };
+            };
+            buildConfigurationList = 0062EB732900222600B0A6AB /* Build configuration list for PBXProject "Gom4ziz" */;
+            compatibilityVersion = "Xcode 14.0";
+            developmentRegion = en;
+            hasScannedForEncodings = 0;
+            knownRegions = (
+                en,
+                Base,
+            );
+            mainGroup = 0062EB6F2900222600B0A6AB;
+            packageReferences = (
+                001B1C8429010C4B00F5C875 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+                001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */,
+                000A52FD2904D43400CEDACC /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */,
+                E68685CF290FAB3000674CC4 /* XCRemoteSwiftPackageReference "KeychainPackage" */,
+            );
+            productRefGroup = 0062EB792900222600B0A6AB /* Products */;
+            projectDirPath = "";
+            projectRoot = "";
+            targets = (
+                0062EB772900222600B0A6AB /* Gom4ziz */,
+                003E5E512902CF89004C597A /* Gom4zizTests */,
+            );
+        };
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		003E5E502902CF89004C597A /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		0062EB762900222600B0A6AB /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0062EBAD290023A600B0A6AB /* .swiftlint.yml in Resources */,
-				0062EB882900222700B0A6AB /* LaunchScreen.storyboard in Resources */,
-				0062EB852900222700B0A6AB /* Assets.xcassets in Resources */,
-				0062EB832900222600B0A6AB /* Main.storyboard in Resources */,
-				E6F4878B290982AC00037CF9 /* GoogleService-Info.plist in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+        003E5E502902CF89004C597A /* Resources */ = {
+            isa = PBXResourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        0062EB762900222600B0A6AB /* Resources */ = {
+            isa = PBXResourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                0062EBAD290023A600B0A6AB /* .swiftlint.yml in Resources */,
+                0062EB882900222700B0A6AB /* LaunchScreen.storyboard in Resources */,
+                0062EB852900222700B0A6AB /* Assets.xcassets in Resources */,
+                0062EB832900222600B0A6AB /* Main.storyboard in Resources */,
+                E6F4878B290982AC00037CF9 /* GoogleService-Info.plist in Resources */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0062EBAB2900234700B0A6AB /* Swiftlint script */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Swiftlint script";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\" \nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
+        0062EBAB2900234700B0A6AB /* Swiftlint script */ = {
+            isa = PBXShellScriptBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+            );
+            inputFileListPaths = (
+            );
+            inputPaths = (
+            );
+            name = "Swiftlint script";
+            outputFileListPaths = (
+            );
+            outputPaths = (
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+            shellPath = /bin/sh;
+            shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\" \nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+        };
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		003E5E4E2902CF89004C597A /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				00A12CED290651980024934C /* DeeplinkParserTests.swift in Sources */,
-				003E5E602902D1A6004C597A /* UserInfoRepositoryTests.swift in Sources */,
-				F251F36329055245003B6690 /* PlansRoomRepositoryTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		0062EB742900222600B0A6AB /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				001B1C7F2900FCC800F5C875 /* UserInfo.swift in Sources */,
-				00953D162909008C0022D6A4 /* JoinPlansRoomUsecase.swift in Sources */,
-				001B1C832901049400F5C875 /* MockData.swift in Sources */,
-				F251F35C2903EDA5003B6690 /* PlansRoomListViewController.swift in Sources */,
-				E63C75602909166200133C9E /* AppleTestView.swift in Sources */,
-				E63C75642909171100133C9E /* AppleLoginManager.swift in Sources */,
-				002821EF2901884100717E2C /* ProcessInfo.swift in Sources */,
-				007EA00D2906290B000B8E31 /* DeeplinkHandler.swift in Sources */,
-				000A53152904F33800CEDACC /* ShareTestView.swift in Sources */,
-				000A531C29050CB400CEDACC /* KakaoMessage.swift in Sources */,
-				000A531F29050DA700CEDACC /* SendInviteUsecase.swift in Sources */,
-				CCF71D1D2907CFED00C66C55 /* KakaoLoginView.swift in Sources */,
-				001B1C812900FE5B00F5C875 /* PlansRoom.swift in Sources */,
-				001B1C812900FE5B00F5C875 /* PlansRoom.swift in Sources */,
-				0062EB7C2900222600B0A6AB /* AppDelegate.swift in Sources */,
-				002821F829022B2100717E2C /* UserInfoIdCache.swift in Sources */,
-				F251F35F290549EF003B6690 /* PlansRoomRepository.swift in Sources */,
-				007EA01129062E1D000B8E31 /* Deeplink.swift in Sources */,
-				CCBFB77129090E3500173FD7 /* LoginViewModel.swift in Sources */,
-				CC381334290A6B96009DD5F3 /* KakaoLoginManager.swift in Sources */,
-				CCBFB77129090E3500173FD7 /* LoginViewModel.swift in Sources */,
-				CCF71D1F2907CFF900C66C55 /* KakaoLoginViewController.swift in Sources */,
-				002821F12901889000717E2C /* UserInfoRepository.swift in Sources */,
-				007EA01329062E4C000B8E31 /* DeeplinkParser.swift in Sources */,
-				000A53122904F31A00CEDACC /* ShareTestViewController.swift in Sources */,
-				CC381332290A6B86009DD5F3 /* LoginManagerProtocol.swift in Sources */,
-				0062EB7E2900222600B0A6AB /* SceneDelegate.swift in Sources */,
-				E63C75622909166900133C9E /* AppleTestViewController.swift in Sources */,
-				000A53082904D85700CEDACC /* APIKey.swift in Sources */,
-				002821F329018E7700717E2C /* RxSwift+Firestore.swift in Sources */,
-				000A53172904F38800CEDACC /* SwiftUI+UIKit.swift in Sources */,
-				000A530D2904E27400CEDACC /* KakaoMessageSender.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+        003E5E4E2902CF89004C597A /* Sources */ = {
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                00A12CED290651980024934C /* DeeplinkParserTests.swift in Sources */,
+                003E5E602902D1A6004C597A /* UserInfoRepositoryTests.swift in Sources */,
+                F251F36329055245003B6690 /* PlansRoomRepositoryTests.swift in Sources */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        0062EB742900222600B0A6AB /* Sources */ = {
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                001B1C7F2900FCC800F5C875 /* UserInfo.swift in Sources */,
+                00953D162909008C0022D6A4 /* JoinPlansRoomUsecase.swift in Sources */,
+                001B1C832901049400F5C875 /* MockData.swift in Sources */,
+                F251F35C2903EDA5003B6690 /* PlansRoomListViewController.swift in Sources */,
+                E63C75602909166200133C9E /* AppleTestView.swift in Sources */,
+                E63C75642909171100133C9E /* AppleLoginManager.swift in Sources */,
+                002821EF2901884100717E2C /* ProcessInfo.swift in Sources */,
+                007EA00D2906290B000B8E31 /* DeeplinkHandler.swift in Sources */,
+                000A53152904F33800CEDACC /* ShareTestView.swift in Sources */,
+                000A531C29050CB400CEDACC /* KakaoMessage.swift in Sources */,
+                000A531F29050DA700CEDACC /* SendInviteUsecase.swift in Sources */,
+                CCF71D1D2907CFED00C66C55 /* KakaoLoginView.swift in Sources */,
+                001B1C812900FE5B00F5C875 /* PlansRoom.swift in Sources */,
+                001B1C812900FE5B00F5C875 /* PlansRoom.swift in Sources */,
+                0062EB7C2900222600B0A6AB /* AppDelegate.swift in Sources */,
+                002821F829022B2100717E2C /* UserInfoIdCache.swift in Sources */,
+                F251F35F290549EF003B6690 /* PlansRoomRepository.swift in Sources */,
+                007EA01129062E1D000B8E31 /* Deeplink.swift in Sources */,
+                CCBFB77129090E3500173FD7 /* LoginViewModel.swift in Sources */,
+                CC381334290A6B96009DD5F3 /* KakaoLoginManager.swift in Sources */,
+                CCBFB77129090E3500173FD7 /* LoginViewModel.swift in Sources */,
+                CCF71D1F2907CFF900C66C55 /* KakaoLoginViewController.swift in Sources */,
+                002821F12901889000717E2C /* UserInfoRepository.swift in Sources */,
+                007EA01329062E4C000B8E31 /* DeeplinkParser.swift in Sources */,
+                000A53122904F31A00CEDACC /* ShareTestViewController.swift in Sources */,
+                CC381332290A6B86009DD5F3 /* LoginManagerProtocol.swift in Sources */,
+                0062EB7E2900222600B0A6AB /* SceneDelegate.swift in Sources */,
+                E63C75622909166900133C9E /* AppleTestViewController.swift in Sources */,
+                000A53082904D85700CEDACC /* APIKey.swift in Sources */,
+                002821F329018E7700717E2C /* RxSwift+Firestore.swift in Sources */,
+                000A53172904F38800CEDACC /* SwiftUI+UIKit.swift in Sources */,
+                000A530D2904E27400CEDACC /* KakaoMessageSender.swift in Sources */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		003E5E572902CF89004C597A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 0062EB772900222600B0A6AB /* Gom4ziz */;
-			targetProxy = 003E5E562902CF89004C597A /* PBXContainerItemProxy */;
-		};
+        003E5E572902CF89004C597A /* PBXTargetDependency */ = {
+            isa = PBXTargetDependency;
+            target = 0062EB772900222600B0A6AB /* Gom4ziz */;
+            targetProxy = 003E5E562902CF89004C597A /* PBXContainerItemProxy */;
+        };
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-		0062EB812900222600B0A6AB /* Main.storyboard */ = {
-			isa = PBXVariantGroup;
-			children = (
-				0062EB822900222600B0A6AB /* Base */,
-			);
-			name = Main.storyboard;
-			sourceTree = "<group>";
-		};
-		0062EB862900222700B0A6AB /* LaunchScreen.storyboard */ = {
-			isa = PBXVariantGroup;
-			children = (
-				0062EB872900222700B0A6AB /* Base */,
-			);
-			name = LaunchScreen.storyboard;
-			sourceTree = "<group>";
-		};
+        0062EB812900222600B0A6AB /* Main.storyboard */ = {
+            isa = PBXVariantGroup;
+            children = (
+                0062EB822900222600B0A6AB /* Base */,
+            );
+            name = Main.storyboard;
+            sourceTree = "<group>";
+        };
+        0062EB862900222700B0A6AB /* LaunchScreen.storyboard */ = {
+            isa = PBXVariantGroup;
+            children = (
+                0062EB872900222700B0A6AB /* Base */,
+            );
+            name = LaunchScreen.storyboard;
+            sourceTree = "<group>";
+        };
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		003E5E592902CF89004C597A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = team.gom4ziz.Gom4zizTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Gom4ziz.app/Gom4ziz";
-			};
-			name = Debug;
-		};
-		003E5E5A2902CF89004C597A /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = team.gom4ziz.Gom4zizTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Gom4ziz.app/Gom4ziz";
-			};
-			name = Release;
-		};
-		0062EBA02900222700B0A6AB /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-			};
-			name = Debug;
-		};
-		0062EBA12900222700B0A6AB /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				MTL_FAST_MATH = YES;
-				SDKROOT = iphoneos;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		0062EBA32900222700B0A6AB /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = Gom4ziz/Gom4ziz.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 44RS35G3C5;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 953VJTV7TA;
-				DEVELOPMENT_TEAM = J7ZP3WYXRW;
-				DEVELOPMENT_TEAM = "";
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = Gom4ziz/Resources/Info.plist;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = team.gom4ziz.Ziz4gom;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = gom4ziz;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		0062EBA42900222700B0A6AB /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = Gom4ziz/Gom4ziz.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 953VJTV7TA;
-				CODE_SIGN_STYLE = Automatic;
-				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = Gom4ziz/Resources/Info.plist;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = team.gom4ziz.Ziz4gom;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = gom4ziz;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
+        003E5E592902CF89004C597A /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                BUNDLE_LOADER = "$(TEST_HOST)";
+                CLANG_ENABLE_MODULES = YES;
+                CODE_SIGN_STYLE = Automatic;
+                CURRENT_PROJECT_VERSION = 1;
+                GENERATE_INFOPLIST_FILE = YES;
+                IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+                LD_RUNPATH_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "@executable_path/Frameworks",
+                    "@loader_path/Frameworks",
+                );
+                MARKETING_VERSION = 1.0;
+                PRODUCT_BUNDLE_IDENTIFIER = team.gom4ziz.Gom4zizTests;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_EMIT_LOC_STRINGS = NO;
+                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+                SWIFT_VERSION = 5.0;
+                TARGETED_DEVICE_FAMILY = "1,2";
+                TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Gom4ziz.app/Gom4ziz";
+            };
+            name = Debug;
+        };
+        003E5E5A2902CF89004C597A /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                BUNDLE_LOADER = "$(TEST_HOST)";
+                CLANG_ENABLE_MODULES = YES;
+                CODE_SIGN_STYLE = Automatic;
+                CURRENT_PROJECT_VERSION = 1;
+                GENERATE_INFOPLIST_FILE = YES;
+                IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+                LD_RUNPATH_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "@executable_path/Frameworks",
+                    "@loader_path/Frameworks",
+                );
+                MARKETING_VERSION = 1.0;
+                PRODUCT_BUNDLE_IDENTIFIER = team.gom4ziz.Gom4zizTests;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_EMIT_LOC_STRINGS = NO;
+                SWIFT_VERSION = 5.0;
+                TARGETED_DEVICE_FAMILY = "1,2";
+                TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Gom4ziz.app/Gom4ziz";
+            };
+            name = Release;
+        };
+        0062EBA02900222700B0A6AB /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ALWAYS_SEARCH_USER_PATHS = NO;
+                CLANG_ANALYZER_NONNULL = YES;
+                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+                CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+                CLANG_ENABLE_MODULES = YES;
+                CLANG_ENABLE_OBJC_ARC = YES;
+                CLANG_ENABLE_OBJC_WEAK = YES;
+                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+                CLANG_WARN_BOOL_CONVERSION = YES;
+                CLANG_WARN_COMMA = YES;
+                CLANG_WARN_CONSTANT_CONVERSION = YES;
+                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+                CLANG_WARN_EMPTY_BODY = YES;
+                CLANG_WARN_ENUM_CONVERSION = YES;
+                CLANG_WARN_INFINITE_RECURSION = YES;
+                CLANG_WARN_INT_CONVERSION = YES;
+                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+                CLANG_WARN_STRICT_PROTOTYPES = YES;
+                CLANG_WARN_SUSPICIOUS_MOVE = YES;
+                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+                CLANG_WARN_UNREACHABLE_CODE = YES;
+                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+                COPY_PHASE_STRIP = NO;
+                DEBUG_INFORMATION_FORMAT = dwarf;
+                ENABLE_STRICT_OBJC_MSGSEND = YES;
+                ENABLE_TESTABILITY = YES;
+                GCC_C_LANGUAGE_STANDARD = gnu11;
+                GCC_DYNAMIC_NO_PIC = NO;
+                GCC_NO_COMMON_BLOCKS = YES;
+                GCC_OPTIMIZATION_LEVEL = 0;
+                GCC_PREPROCESSOR_DEFINITIONS = (
+                    "DEBUG=1",
+                    "$(inherited)",
+                );
+                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+                GCC_WARN_UNDECLARED_SELECTOR = YES;
+                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+                GCC_WARN_UNUSED_FUNCTION = YES;
+                GCC_WARN_UNUSED_VARIABLE = YES;
+                IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+                MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+                MTL_FAST_MATH = YES;
+                ONLY_ACTIVE_ARCH = YES;
+                SDKROOT = iphoneos;
+                SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+            };
+            name = Debug;
+        };
+        0062EBA12900222700B0A6AB /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ALWAYS_SEARCH_USER_PATHS = NO;
+                CLANG_ANALYZER_NONNULL = YES;
+                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+                CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+                CLANG_ENABLE_MODULES = YES;
+                CLANG_ENABLE_OBJC_ARC = YES;
+                CLANG_ENABLE_OBJC_WEAK = YES;
+                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+                CLANG_WARN_BOOL_CONVERSION = YES;
+                CLANG_WARN_COMMA = YES;
+                CLANG_WARN_CONSTANT_CONVERSION = YES;
+                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+                CLANG_WARN_EMPTY_BODY = YES;
+                CLANG_WARN_ENUM_CONVERSION = YES;
+                CLANG_WARN_INFINITE_RECURSION = YES;
+                CLANG_WARN_INT_CONVERSION = YES;
+                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+                CLANG_WARN_STRICT_PROTOTYPES = YES;
+                CLANG_WARN_SUSPICIOUS_MOVE = YES;
+                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+                CLANG_WARN_UNREACHABLE_CODE = YES;
+                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+                COPY_PHASE_STRIP = NO;
+                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+                ENABLE_NS_ASSERTIONS = NO;
+                ENABLE_STRICT_OBJC_MSGSEND = YES;
+                GCC_C_LANGUAGE_STANDARD = gnu11;
+                GCC_NO_COMMON_BLOCKS = YES;
+                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+                GCC_WARN_UNDECLARED_SELECTOR = YES;
+                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+                GCC_WARN_UNUSED_FUNCTION = YES;
+                GCC_WARN_UNUSED_VARIABLE = YES;
+                IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+                MTL_ENABLE_DEBUG_INFO = NO;
+                MTL_FAST_MATH = YES;
+                SDKROOT = iphoneos;
+                SWIFT_COMPILATION_MODE = wholemodule;
+                SWIFT_OPTIMIZATION_LEVEL = "-O";
+                VALIDATE_PRODUCT = YES;
+            };
+            name = Release;
+        };
+        0062EBA32900222700B0A6AB /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+                CODE_SIGN_ENTITLEMENTS = Gom4ziz/Gom4ziz.entitlements;
+                CODE_SIGN_IDENTITY = "Apple Development";
+                CODE_SIGN_STYLE = Manual;
+                CURRENT_PROJECT_VERSION = 1;
+                DEVELOPMENT_TEAM = 44RS35G3C5;
+                "CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+                CODE_SIGN_STYLE = Manual;
+                CURRENT_PROJECT_VERSION = 1;
+                DEVELOPMENT_TEAM = "";
+                "DEVELOPMENT_TEAM[sdk=iphoneos*]" = 953VJTV7TA;
+                GENERATE_INFOPLIST_FILE = YES;
+                INFOPLIST_FILE = Gom4ziz/Resources/Info.plist;
+                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+                INFOPLIST_KEY_UIMainStoryboardFile = Main;
+                INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+                IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+                LD_RUNPATH_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "@executable_path/Frameworks",
+                );
+                MARKETING_VERSION = 0.0;
+                PRODUCT_BUNDLE_IDENTIFIER = team.gom4ziz.Ziz4gom;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                PROVISIONING_PROFILE_SPECIFIER = "";
+                "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = gom4ziz;
+                SWIFT_EMIT_LOC_STRINGS = YES;
+                SWIFT_VERSION = 5.0;
+                TARGETED_DEVICE_FAMILY = "1,2";
+            };
+            name = Debug;
+        };
+        0062EBA42900222700B0A6AB /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+                CODE_SIGN_ENTITLEMENTS = Gom4ziz/Gom4ziz.entitlements;
+                CODE_SIGN_IDENTITY = "Apple Development";
+                "CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+                CODE_SIGN_STYLE = Manual;
+                CURRENT_PROJECT_VERSION = 1;
+                DEVELOPMENT_TEAM = "";
+                "DEVELOPMENT_TEAM[sdk=iphoneos*]" = 953VJTV7TA;
+                GENERATE_INFOPLIST_FILE = YES;
+                INFOPLIST_FILE = Gom4ziz/Resources/Info.plist;
+                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+                INFOPLIST_KEY_UIMainStoryboardFile = Main;
+                INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+                IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+                LD_RUNPATH_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "@executable_path/Frameworks",
+                );
+                MARKETING_VERSION = 0.0;
+                PRODUCT_BUNDLE_IDENTIFIER = team.gom4ziz.Ziz4gom;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                PROVISIONING_PROFILE_SPECIFIER = "";
+                "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = gom4ziz;
+                SWIFT_EMIT_LOC_STRINGS = YES;
+                SWIFT_VERSION = 5.0;
+                TARGETED_DEVICE_FAMILY = "1,2";
+            };
+            name = Release;
+        };
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		003E5E582902CF89004C597A /* Build configuration list for PBXNativeTarget "Gom4zizTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				003E5E592902CF89004C597A /* Debug */,
-				003E5E5A2902CF89004C597A /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		0062EB732900222600B0A6AB /* Build configuration list for PBXProject "Gom4ziz" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0062EBA02900222700B0A6AB /* Debug */,
-				0062EBA12900222700B0A6AB /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		0062EBA22900222700B0A6AB /* Build configuration list for PBXNativeTarget "Gom4ziz" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0062EBA32900222700B0A6AB /* Debug */,
-				0062EBA42900222700B0A6AB /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
+        003E5E582902CF89004C597A /* Build configuration list for PBXNativeTarget "Gom4zizTests" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                003E5E592902CF89004C597A /* Debug */,
+                003E5E5A2902CF89004C597A /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+        0062EB732900222600B0A6AB /* Build configuration list for PBXProject "Gom4ziz" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                0062EBA02900222700B0A6AB /* Debug */,
+                0062EBA12900222700B0A6AB /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+        0062EBA22900222700B0A6AB /* Build configuration list for PBXNativeTarget "Gom4ziz" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                0062EBA32900222700B0A6AB /* Debug */,
+                0062EBA42900222700B0A6AB /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		000A52FD2904D43400CEDACC /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/kakao/kakao-ios-sdk-rx";
-			requirement = {
-				branch = master;
-				kind = branch;
-			};
-		};
-		001B1C8429010C4B00F5C875 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
-			};
-		};
-		001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ReactiveX/RxSwift";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 6.0.0;
-			};
-		};
-		E68685CF290FAB3000674CC4 /* XCRemoteSwiftPackageReference "KeychainPackage" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/HoJongE/KeychainPackage.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
-			};
-		};
+        000A52FD2904D43400CEDACC /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */ = {
+            isa = XCRemoteSwiftPackageReference;
+            repositoryURL = "https://github.com/kakao/kakao-ios-sdk-rx";
+            requirement = {
+                branch = master;
+                kind = branch;
+            };
+        };
+        001B1C8429010C4B00F5C875 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+            isa = XCRemoteSwiftPackageReference;
+            repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+            requirement = {
+                kind = upToNextMajorVersion;
+                minimumVersion = 9.0.0;
+            };
+        };
+        001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
+            isa = XCRemoteSwiftPackageReference;
+            repositoryURL = "https://github.com/ReactiveX/RxSwift";
+            requirement = {
+                kind = upToNextMajorVersion;
+                minimumVersion = 6.0.0;
+            };
+        };
+        E68685CF290FAB3000674CC4 /* XCRemoteSwiftPackageReference "KeychainPackage" */ = {
+            isa = XCRemoteSwiftPackageReference;
+            repositoryURL = "https://github.com/HoJongE/KeychainPackage.git";
+            requirement = {
+                kind = upToNextMajorVersion;
+                minimumVersion = 1.0.0;
+            };
+        };
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		000A52FE2904D43400CEDACC /* RxKakaoSDKCommon */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 000A52FD2904D43400CEDACC /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
-			productName = RxKakaoSDKCommon;
-		};
-		000A53002904D43400CEDACC /* RxKakaoSDKShare */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 000A52FD2904D43400CEDACC /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
-			productName = RxKakaoSDKShare;
-		};
-		001B1C8529010C4B00F5C875 /* FirebaseAuth */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 001B1C8429010C4B00F5C875 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAuth;
-		};
-		001B1C8729010C4B00F5C875 /* FirebaseFirestore */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 001B1C8429010C4B00F5C875 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseFirestore;
-		};
-		001B1CA32901270C00F5C875 /* RxCocoa */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */;
-			productName = RxCocoa;
-		};
-		001B1CA52901270C00F5C875 /* RxRelay */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */;
-			productName = RxRelay;
-		};
-		001B1CA72901270C00F5C875 /* RxSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */;
-			productName = RxSwift;
-		};
-		002821F52901932A00717E2C /* FirebaseFirestoreSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 001B1C8429010C4B00F5C875 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseFirestoreSwift;
-		};
-		003E5E5B2902D0FA004C597A /* RxBlocking */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */;
-			productName = RxBlocking;
-		};
-		003E5E5D2902D0FA004C597A /* RxTest */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */;
-			productName = RxTest;
-		};
-		E68685D0290FAB3100674CC4 /* KeyChainWrapper */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E68685CF290FAB3000674CC4 /* XCRemoteSwiftPackageReference "KeychainPackage" */;
-			productName = KeyChainWrapper;
-		CCF71D202907D02600C66C55 /* RxKakaoSDKAuth */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 000A52FD2904D43400CEDACC /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
-			productName = RxKakaoSDKAuth;
-		};
-		CCF71D222907D03600C66C55 /* RxKakaoSDKUser */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 000A52FD2904D43400CEDACC /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
-			productName = RxKakaoSDKUser;
-		};
+        000A52FE2904D43400CEDACC /* RxKakaoSDKCommon */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = 000A52FD2904D43400CEDACC /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
+            productName = RxKakaoSDKCommon;
+        };
+        000A53002904D43400CEDACC /* RxKakaoSDKShare */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = 000A52FD2904D43400CEDACC /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
+            productName = RxKakaoSDKShare;
+        };
+        001B1C8529010C4B00F5C875 /* FirebaseAuth */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = 001B1C8429010C4B00F5C875 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+            productName = FirebaseAuth;
+        };
+        001B1C8729010C4B00F5C875 /* FirebaseFirestore */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = 001B1C8429010C4B00F5C875 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+            productName = FirebaseFirestore;
+        };
+        001B1CA32901270C00F5C875 /* RxCocoa */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = 001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */;
+            productName = RxCocoa;
+        };
+        001B1CA52901270C00F5C875 /* RxRelay */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = 001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */;
+            productName = RxRelay;
+        };
+        001B1CA72901270C00F5C875 /* RxSwift */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = 001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */;
+            productName = RxSwift;
+        };
+        002821F52901932A00717E2C /* FirebaseFirestoreSwift */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = 001B1C8429010C4B00F5C875 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+            productName = FirebaseFirestoreSwift;
+        };
+        003E5E5B2902D0FA004C597A /* RxBlocking */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = 001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */;
+            productName = RxBlocking;
+        };
+        003E5E5D2902D0FA004C597A /* RxTest */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = 001B1CA22901270C00F5C875 /* XCRemoteSwiftPackageReference "RxSwift" */;
+            productName = RxTest;
+        };
+        CCF71D202907D02600C66C55 /* RxKakaoSDKAuth */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = 000A52FD2904D43400CEDACC /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
+            productName = RxKakaoSDKAuth;
+        };
+        CCF71D222907D03600C66C55 /* RxKakaoSDKUser */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = 000A52FD2904D43400CEDACC /* XCRemoteSwiftPackageReference "kakao-ios-sdk-rx" */;
+            productName = RxKakaoSDKUser;
+    };
+        E68685D0290FAB3100674CC4 /* KeyChainWrapper */ = {
+            isa = XCSwiftPackageProductDependency;
+            package = E68685CF290FAB3000674CC4 /* XCRemoteSwiftPackageReference "KeychainPackage" */;
+            productName = KeyChainWrapper;
+        };
 /* End XCSwiftPackageProductDependency section */
-	};
-	rootObject = 0062EB702900222600B0A6AB /* Project object */;
+    };
+    rootObject = 0062EB702900222600B0A6AB /* Project object */;
 }

--- a/Gom4ziz/Gom4ziz/Domain/Model/UserInfo.swift
+++ b/Gom4ziz/Gom4ziz/Domain/Model/UserInfo.swift
@@ -10,16 +10,22 @@ import Foundation
 struct UserInfo: Identifiable, Codable, Hashable {
     let id: String
     let name: String
+    let imageURL: URL?
+    init(id: String, name: String, imageURL: URL? = nil) {
+        self.id = id
+        self.name = name
+        self.imageURL = imageURL
+    }
 }
 
 extension UserInfo: Equatable {
     static func == (lhs: UserInfo, rhs: UserInfo) -> Bool {
-        lhs.id == rhs.id && lhs.name == rhs.name
+        lhs.id == rhs.id && lhs.name == rhs.name && lhs.imageURL == rhs.imageURL
     }
 }
 
 extension UserInfo: CustomStringConvertible {
     var description: String {
-        "유저 아이디: \(id) 유저 이름: \(name)"
+        "유저 아이디: \(id) 유저 이름: \(name) 이미지 url: \(String(describing: imageURL))"
     }
 }

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginManager.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginManager.swift
@@ -4,6 +4,7 @@
 //
 //  Created by 이가은 on 2022/10/27.
 //
+import UIKit
 
 import KakaoSDKAuth
 import KakaoSDKCommon
@@ -13,7 +14,6 @@ import RxSwift
 import RxKakaoSDKAuth
 import RxKakaoSDKCommon
 import RxKakaoSDKUser
-import UIKit
 
 struct KakaoLoginManager: LoginManagerProtocol {
     private let disposeBag: DisposeBag = DisposeBag()

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginManager.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginManager.swift
@@ -32,44 +32,44 @@ struct KakaoLoginManager: LoginManagerProtocol {
         UserApi.shared.rx.loginWithKakaoTalk()
             .subscribe(onNext: { (oauthToken) in
                 print("loginWithKakaoTalk() success.")
-                self.getUserInfo()
+                getUserInfo()
                 _ = oauthToken
             }, onError: {error in
                 print(error)
             })
-            .disposed(by: self.disposeBag)
+            .disposed(by: disposeBag)
     }
     
     private func loginWithKakaoAccount() {
         UserApi.shared.rx.loginWithKakaoAccount()
             .subscribe(onNext: { (oauthToken) in
                 print("loginWithKakaoAccount() success.")
-                self.getUserInfo()
+                getUserInfo()
                 _ = oauthToken
             }, onError: {error in
                 print(error)
             })
-            .disposed(by: self.disposeBag)
+            .disposed(by: disposeBag)
     }
     
     func logout() {
         UserApi.shared.rx.logout()
             .subscribe(onCompleted: {
                 print("logout() success.")
-                self.userInfo.accept(UserInfo(id: UUID().uuidString, name: "로그아웃 성공", imageURL: nil))
-                self.loginstatus.accept(.logout)
+                userInfo.accept(UserInfo(id: UUID().uuidString, name: "로그아웃 성공", imageURL: nil))
+                loginstatus.accept(.logout)
             }, onError: { error in
                 print(error)
             })
             .disposed(by: disposeBag)
     }
     
-    func unlink() {
+    func withDrawal() {
         UserApi.shared.rx.unlink()
             .subscribe(onCompleted: {
-                print("unlink() success.")
-                self.userInfo.accept(UserInfo(id: UUID().uuidString, name: "회원 탈퇴 성공", imageURL: nil))
-                self.loginstatus.accept(.unlink)
+                print("withDrawal() success.")
+                userInfo.accept(UserInfo(id: UUID().uuidString, name: "회원 탈퇴 성공", imageURL: nil))
+                loginstatus.accept(.withDrawal)
             }, onError: {error in
                 print(error)
             })
@@ -81,10 +81,9 @@ struct KakaoLoginManager: LoginManagerProtocol {
             .subscribe(onSuccess: { user in
                 print("me() success.")
                 if let name = user.kakaoAccount?.profile?.nickname {
-                    self.userInfo.accept(UserInfo(id: UUID().uuidString, name: name, imageURL: user.kakaoAccount?.profile?.profileImageUrl))
+                    userInfo.accept(UserInfo(id: UUID().uuidString, name: name, imageURL: user.kakaoAccount?.profile?.profileImageUrl))
                 }
-                self.loginstatus.accept(.login)
-                _ = user
+                loginstatus.accept(.login)
             }, onFailure: {error in
                 print(error)
             })

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginManager.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginManager.swift
@@ -1,54 +1,57 @@
 //
-//  KakaoLoginViewModel.swift
+//  KakaoLoginManager.swift
 //  Gom4ziz
 //
-//  Created by 이가은 on 2022/10/26.
+//  Created by 이가은 on 2022/10/27.
 //
 
-import UIKit
-import RxSwift
-import KakaoSDKCommon
-import RxKakaoSDKCommon
 import KakaoSDKAuth
-import RxKakaoSDKAuth
+import KakaoSDKCommon
 import KakaoSDKUser
-import RxKakaoSDKUser
 import RxCocoa
+import RxSwift
+import RxKakaoSDKAuth
+import RxKakaoSDKCommon
+import RxKakaoSDKUser
+import UIKit
 
-final class KakaoLoginViewModel {
+struct KakaoLoginManager: LoginManagerProtocol {
     private let disposeBag: DisposeBag = DisposeBag()
     let userInfo: PublishRelay<UserInfo> = .init()
     let kakaoLoginstatus: PublishRelay<KakaoLoginstatus> = .init()
-    enum KakaoLoginstatus {
-        case login
-        case logout
-        case unlink
-    }
-    init() {
-    }
-    func loginWithKakao() {
+    
+    func login() {
         if UserApi.isKakaoTalkLoginAvailable() {
-            UserApi.shared.rx.loginWithKakaoTalk()
-                .subscribe(onNext: { (oauthToken) in
-                    print("loginWithKakaoTalk() success.")
-                    self.getUserInfo()
-                    _ = oauthToken
-                }, onError: {error in
-                    print(error)
-                })
-                .disposed(by: self.disposeBag)
+            loginWithKakaoTalk()
         } else {
-            UserApi.shared.rx.loginWithKakaoAccount()
-                .subscribe(onNext: { (oauthToken) in
-                    print("loginWithKakaoAccount() success.")
-                    self.getUserInfo()
-                    _ = oauthToken
-                }, onError: {error in
-                    print(error)
-                })
-                .disposed(by: self.disposeBag)
+            loginWithKakaoAccount()
         }
     }
+    
+    private func loginWithKakaoTalk() {
+        UserApi.shared.rx.loginWithKakaoTalk()
+            .subscribe(onNext: { (oauthToken) in
+                print("loginWithKakaoTalk() success.")
+                self.getUserInfo()
+                _ = oauthToken
+            }, onError: {error in
+                print(error)
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
+    private func loginWithKakaoAccount() {
+        UserApi.shared.rx.loginWithKakaoAccount()
+            .subscribe(onNext: { (oauthToken) in
+                print("loginWithKakaoAccount() success.")
+                self.getUserInfo()
+                _ = oauthToken
+            }, onError: {error in
+                print(error)
+            })
+            .disposed(by: self.disposeBag)
+    }
+    
     func logout() {
         UserApi.shared.rx.logout()
             .subscribe(onCompleted: {
@@ -60,6 +63,7 @@ final class KakaoLoginViewModel {
             })
             .disposed(by: disposeBag)
     }
+    
     func unlink() {
         UserApi.shared.rx.unlink()
             .subscribe(onCompleted: {
@@ -71,6 +75,7 @@ final class KakaoLoginViewModel {
             })
             .disposed(by: disposeBag)
     }
+    
     func getUserInfo() {
         UserApi.shared.rx.me()
             .subscribe(onSuccess: { user in

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginManager.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginManager.swift
@@ -18,7 +18,7 @@ import UIKit
 struct KakaoLoginManager: LoginManagerProtocol {
     private let disposeBag: DisposeBag = DisposeBag()
     let userInfo: PublishRelay<UserInfo> = .init()
-    let kakaoLoginstatus: PublishRelay<KakaoLoginstatus> = .init()
+    let loginstatus: PublishRelay<Loginstatus> = .init()
     
     func login() {
         if UserApi.isKakaoTalkLoginAvailable() {
@@ -57,7 +57,7 @@ struct KakaoLoginManager: LoginManagerProtocol {
             .subscribe(onCompleted: {
                 print("logout() success.")
                 self.userInfo.accept(UserInfo(id: UUID().uuidString, name: "로그아웃 성공", imageURL: nil))
-                self.kakaoLoginstatus.accept(.logout)
+                self.loginstatus.accept(.logout)
             }, onError: { error in
                 print(error)
             })
@@ -69,7 +69,7 @@ struct KakaoLoginManager: LoginManagerProtocol {
             .subscribe(onCompleted: {
                 print("unlink() success.")
                 self.userInfo.accept(UserInfo(id: UUID().uuidString, name: "회원 탈퇴 성공", imageURL: nil))
-                self.kakaoLoginstatus.accept(.unlink)
+                self.loginstatus.accept(.unlink)
             }, onError: {error in
                 print(error)
             })
@@ -83,7 +83,7 @@ struct KakaoLoginManager: LoginManagerProtocol {
                 if let name = user.kakaoAccount?.profile?.nickname {
                     self.userInfo.accept(UserInfo(id: UUID().uuidString, name: name, imageURL: user.kakaoAccount?.profile?.profileImageUrl))
                 }
-                self.kakaoLoginstatus.accept(.login)
+                self.loginstatus.accept(.login)
                 _ = user
             }, onFailure: {error in
                 print(error)

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginView.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginView.swift
@@ -12,38 +12,53 @@ class KakaoLoginView: UIView {
         var configuration = UIButton.Configuration.tinted()
         configuration.title = "카카오 로그인"
         let button = UIButton(configuration: configuration)
+        addSubview(button)
+        button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
+    
     private (set) lazy var logoutButton: UIButton = {
         var configuration = UIButton.Configuration.tinted()
         configuration.title = "카카오 로그아웃"
         let button = UIButton(configuration: configuration)
+        addSubview(button)
+        button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
+    
     private (set) lazy var unLinkButton: UIButton = {
         var configuration = UIButton.Configuration.tinted()
         configuration.title = "회원 탈퇴"
         let button = UIButton(configuration: configuration)
+        addSubview(button)
+        button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
+    
     lazy var userName: UILabel = {
         let label = UILabel(frame: .zero)
         label.font = .preferredFont(forTextStyle: .title3)
         label.textColor = .white
         label.text = "유저 이름 들어갈 자리"
+        addSubview(label)
+        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
+    
     lazy var userImageView: UIImageView = {
-            let ImageView = UIImageView()
-            ImageView.backgroundColor = .red
-            ImageView.translatesAutoresizingMaskIntoConstraints = false
-            return ImageView
-        }()
-
+        let ImageView = UIImageView()
+        ImageView.backgroundColor = .red
+        ImageView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(ImageView)
+        ImageView.translatesAutoresizingMaskIntoConstraints = false
+        return ImageView
+    }()
+    
     override init(frame: CGRect) {
         super.init(frame: .zero)
         setUpViews()
     }
+    
     required init?(coder: NSCoder) {
         fatalError("Don`t need to implement")
     }
@@ -52,17 +67,8 @@ private extension KakaoLoginView {
     func setUpViews() {
         setUpAutoLayout()
     }
+    
     func setUpAutoLayout() {
-        addSubview(loginButton)
-        addSubview(userName)
-        addSubview(userImageView)
-        addSubview(logoutButton)
-        addSubview(unLinkButton)
-        loginButton.translatesAutoresizingMaskIntoConstraints = false
-        userName.translatesAutoresizingMaskIntoConstraints = false
-        userImageView.translatesAutoresizingMaskIntoConstraints = false
-        logoutButton.translatesAutoresizingMaskIntoConstraints = false
-        unLinkButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             loginButton.topAnchor.constraint(equalTo: topAnchor, constant: 100),
             loginButton.centerXAnchor.constraint(equalTo: centerXAnchor)

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginView.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class KakaoLoginView: UIView {
+final class KakaoLoginView: UIView {
     private (set) lazy var loginButton: UIButton = {
         var configuration = UIButton.Configuration.tinted()
         configuration.title = "카카오 로그인"

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginView.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginView.swift
@@ -1,0 +1,96 @@
+//
+//  KakaoLoginView.swift
+//  Gom4ziz
+//
+//  Created by 이가은 on 2022/10/21.
+//
+
+import UIKit
+
+class KakaoLoginView: UIView {
+    private (set) lazy var loginButton: UIButton = {
+        var configuration = UIButton.Configuration.tinted()
+        configuration.title = "카카오 로그인"
+        let button = UIButton(configuration: configuration)
+        return button
+    }()
+    private (set) lazy var logoutButton: UIButton = {
+        var configuration = UIButton.Configuration.tinted()
+        configuration.title = "카카오 로그아웃"
+        let button = UIButton(configuration: configuration)
+        return button
+    }()
+    private (set) lazy var unLinkButton: UIButton = {
+        var configuration = UIButton.Configuration.tinted()
+        configuration.title = "회원 탈퇴"
+        let button = UIButton(configuration: configuration)
+        return button
+    }()
+    lazy var userName: UILabel = {
+        let label = UILabel(frame: .zero)
+        label.font = .preferredFont(forTextStyle: .title3)
+        label.textColor = .white
+        label.text = "유저 이름 들어갈 자리"
+        return label
+    }()
+    lazy var userImageView: UIImageView = {
+            let ImageView = UIImageView()
+            ImageView.backgroundColor = .red
+            ImageView.translatesAutoresizingMaskIntoConstraints = false
+            return ImageView
+        }()
+
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setUpViews()
+    }
+    required init?(coder: NSCoder) {
+        fatalError("Don`t need to implement")
+    }
+}
+private extension KakaoLoginView {
+    func setUpViews() {
+        setUpAutoLayout()
+    }
+    func setUpAutoLayout() {
+        addSubview(loginButton)
+        addSubview(userName)
+        addSubview(userImageView)
+        addSubview(logoutButton)
+        addSubview(unLinkButton)
+        loginButton.translatesAutoresizingMaskIntoConstraints = false
+        userName.translatesAutoresizingMaskIntoConstraints = false
+        userImageView.translatesAutoresizingMaskIntoConstraints = false
+        logoutButton.translatesAutoresizingMaskIntoConstraints = false
+        unLinkButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            loginButton.topAnchor.constraint(equalTo: topAnchor, constant: 100),
+            loginButton.centerXAnchor.constraint(equalTo: centerXAnchor)
+        ])
+        NSLayoutConstraint.activate([
+            userName.topAnchor.constraint(equalTo: loginButton.bottomAnchor, constant: 16),
+            userName.centerXAnchor.constraint(equalTo: centerXAnchor)
+        ])
+        NSLayoutConstraint.activate([
+            logoutButton.topAnchor.constraint(equalTo: userName.bottomAnchor, constant: 16),
+            logoutButton.centerXAnchor.constraint(equalTo: centerXAnchor)
+        ])
+        NSLayoutConstraint.activate([
+            unLinkButton.topAnchor.constraint(equalTo: logoutButton.bottomAnchor, constant: 16),
+            unLinkButton.centerXAnchor.constraint(equalTo: centerXAnchor)
+        ])
+        NSLayoutConstraint.activate([
+            userImageView.topAnchor.constraint(equalTo: unLinkButton.bottomAnchor, constant: 16),
+            userImageView.centerXAnchor.constraint(equalTo: centerXAnchor)
+        ])
+    }
+}
+
+#if DEBUG
+import SwiftUI
+struct KakaoLoginPreView: PreviewProvider {
+    static var previews: some View {
+        KakaoLoginView().toPreview()
+    }
+}
+#endif

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginViewController.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginViewController.swift
@@ -1,0 +1,149 @@
+//
+//  KakaoLoginViewController.swift
+//  Gom4ziz
+//
+//  Created by 이가은 on 2022/10/24.
+//
+
+import UIKit
+import RxSwift
+import KakaoSDKCommon
+import RxKakaoSDKCommon
+import KakaoSDKAuth
+import RxKakaoSDKAuth
+import KakaoSDKUser
+import RxKakaoSDKUser
+
+final class KakaoLoginViewController: UIViewController {
+    private lazy var testView: KakaoLoginView = KakaoLoginView()
+    private let disposeBag: DisposeBag = DisposeBag()
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        isTokenVailed()
+        setObserver()
+    }
+    override func loadView() {
+        self.view = testView
+    }
+}
+
+private extension KakaoLoginViewController {
+    private func isTokenVailed() {
+        if AuthApi.hasToken() {
+            UserApi.shared.rx.accessTokenInfo()
+                .subscribe(onSuccess: { (_) in
+                    print("토큰 유효성 체크 성공(필요 시 토큰 갱신됨)")
+                    self.getUserInfo()
+                }, onFailure: {error in
+                    if let sdkError = error as? SdkError, sdkError.isInvalidTokenError() == true {
+                        print("로그인 필요")
+                    } else {
+                        print("기타 에러")
+                    }
+                })
+                .disposed(by: self.disposeBag)
+        } else {
+            print("로그인 필요")
+        }
+    }
+    func setObserver() {
+        testView.loginButton.rx.tap
+            .bind {
+                self.loginWithKakao()
+            }
+            .disposed(by: disposeBag)
+        testView.logoutButton.rx.tap
+            .bind {
+                self.logout()
+            }
+            .disposed(by: disposeBag)
+        testView.unLinkButton.rx.tap
+            .bind {
+                self.unlink()
+            }
+            .disposed(by: disposeBag)
+    }
+    private func loginWithKakao() {
+        if UserApi.isKakaoTalkLoginAvailable() {
+            UserApi.shared.rx.loginWithKakaoTalk()
+                .subscribe(onNext: { (oauthToken) in
+                    print("loginWithKakaoTalk() success.")
+                    // do something
+                    self.getUserInfo()
+                    _ = oauthToken
+                }, onError: {error in
+                    print(error)
+                })
+                .disposed(by: self.disposeBag)
+        } else {
+            UserApi.shared.rx.loginWithKakaoAccount()
+                .subscribe(onNext: { (oauthToken) in
+                    print("loginWithKakaoAccount() success.")
+                    // do something
+                    self.getUserInfo()
+                    _ = oauthToken
+                }, onError: {error in
+                    print(error)
+                })
+                .disposed(by: self.disposeBag)
+        }
+    }
+    private func logout() {
+        UserApi.shared.rx.logout()
+            .subscribe(onCompleted: {
+                print("logout() success.")
+                self.testView.userName.text = "로그아웃 성공"
+                self.testView.userImageView.isHidden = true
+                self.testView.loginButton.isHidden = false
+                self.testView.logoutButton.isHidden = true
+                self.testView.unLinkButton.isHidden = true
+            }, onError: { error in
+                print(error)
+            })
+            .disposed(by: disposeBag)
+    }
+    private func unlink() {
+        UserApi.shared.rx.unlink()
+            .subscribe(onCompleted: {
+                print("unlink() success.")
+                self.testView.userName.text = "회원 탈퇴 성공"
+                self.testView.userImageView.isHidden = true
+                self.testView.loginButton.isHidden = false
+                self.testView.logoutButton.isHidden = true
+                self.testView.unLinkButton.isHidden = true
+            }, onError: {error in
+                print(error)
+            })
+            .disposed(by: disposeBag)
+    }
+    private func getUserInfo() {
+        UserApi.shared.rx.me()
+            .subscribe(onSuccess: { user in
+                print("me() success.")
+                // do something
+                self.testView.loginButton.isHidden = true
+                self.testView.logoutButton.isHidden = false
+                self.testView.unLinkButton.isHidden = false
+                self.testView.userName.text = user.kakaoAccount?.profile?.nickname
+                self.testView.userImageView.isHidden = false
+                if let url = user.kakaoAccount?.profile?.profileImageUrl,
+                   let data = try? Data(contentsOf: url) {
+                    self.testView.userImageView.image = UIImage(data: data)
+                }
+                _ = user
+            }, onFailure: {error in
+                print(error)
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+#if DEBUG
+import SwiftUI
+import KakaoSDKUser
+struct ViewControllerPreview: PreviewProvider {
+    static var previews: some View {
+        KakaoLoginViewController().toPreview()
+    }
+}
+#endif

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginViewController.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginViewController.swift
@@ -83,7 +83,7 @@ private extension KakaoLoginViewController {
             .bind(to: self.testView.userImageView.rx.image)
             .disposed(by: disposeBag)
         
-        viewmodel.loginManager.kakaoLoginstatus
+        viewmodel.loginManager.loginstatus
             .subscribe(onNext: { status in
                 switch status {
                     case .logout:

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginViewController.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginViewController.swift
@@ -25,7 +25,7 @@ final class KakaoLoginViewController: UIViewController {
         setObserver()
     }
     override func loadView() {
-        self.view = testView
+        view = testView
     }
 }
 
@@ -34,9 +34,9 @@ private extension KakaoLoginViewController {
     func isTokenVailed() {
         if AuthApi.hasToken() {
             UserApi.shared.rx.accessTokenInfo()
-                .subscribe(onSuccess: { (_) in
+                .subscribe(onSuccess: { [self] _ in
                     print("토큰 유효성 체크 성공(필요 시 토큰 갱신됨)")
-                    self.viewmodel.getUserInfo()
+                    viewmodel.getUserInfo()
                 }, onFailure: {error in
                     if let sdkError = error as? SdkError, sdkError.isInvalidTokenError() == true {
                         print("로그인 필요")
@@ -44,7 +44,7 @@ private extension KakaoLoginViewController {
                         print("기타 에러")
                     }
                 })
-                .disposed(by: self.disposeBag)
+                .disposed(by: disposeBag)
         } else {
             print("로그인 필요")
         }
@@ -52,20 +52,20 @@ private extension KakaoLoginViewController {
     
     func setObserver() {
         testView.loginButton.rx.tap
-            .bind {
-                self.viewmodel.loginWithKakao()
+            .bind { [self] _ in
+                viewmodel.loginWithKakao()
             }
             .disposed(by: disposeBag)
         
         testView.logoutButton.rx.tap
-            .bind {
-                self.viewmodel.logout()
+            .bind { [self] _ in
+                viewmodel.logout()
             }
             .disposed(by: disposeBag)
         
         testView.unLinkButton.rx.tap
-            .bind {
-                self.viewmodel.unlink()
+            .bind { [self] _ in
+                viewmodel.withDrawal()
             }
             .disposed(by: disposeBag)
         
@@ -80,27 +80,27 @@ private extension KakaoLoginViewController {
             .compactMap { try Data(contentsOf: $0) }
             .compactMap { UIImage(data: $0) }
             .observe(on: MainScheduler.instance)
-            .bind(to: self.testView.userImageView.rx.image)
+            .bind(to: testView.userImageView.rx.image)
             .disposed(by: disposeBag)
         
         viewmodel.loginManager.loginstatus
-            .subscribe(onNext: { status in
+            .subscribe(onNext: { [self] status in
                 switch status {
                     case .logout:
-                        self.testView.loginButton.isHidden = false
-                        self.testView.userImageView.isHidden = true
-                        self.testView.logoutButton.isHidden = true
-                        self.testView.unLinkButton.isHidden = true
-                    case .unlink:
-                        self.testView.loginButton.isHidden = false
-                        self.testView.userImageView.isHidden = true
-                        self.testView.logoutButton.isHidden = true
-                        self.testView.unLinkButton.isHidden = true
+                        testView.loginButton.isHidden = false
+                        testView.userImageView.isHidden = true
+                        testView.logoutButton.isHidden = true
+                        testView.unLinkButton.isHidden = true
+                    case .withDrawal:
+                        testView.loginButton.isHidden = false
+                        testView.userImageView.isHidden = true
+                        testView.logoutButton.isHidden = true
+                        testView.unLinkButton.isHidden = true
                     case .login:
-                        self.testView.loginButton.isHidden = true
-                        self.testView.userImageView.isHidden = false
-                        self.testView.logoutButton.isHidden = false
-                        self.testView.unLinkButton.isHidden = false
+                        testView.loginButton.isHidden = true
+                        testView.userImageView.isHidden = false
+                        testView.logoutButton.isHidden = false
+                        testView.unLinkButton.isHidden = false
                 }
             })
             .disposed(by: disposeBag)

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginViewController.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginViewController.swift
@@ -4,6 +4,7 @@
 //
 //  Created by 이가은 on 2022/10/24.
 //
+import UIKit
 
 import KakaoSDKAuth
 import KakaoSDKCommon
@@ -13,7 +14,6 @@ import RxSwift
 import RxKakaoSDKAuth
 import RxKakaoSDKCommon
 import RxKakaoSDKUser
-import UIKit
 
 final class KakaoLoginViewController: UIViewController {
     private lazy var testView: KakaoLoginView = KakaoLoginView()
@@ -31,7 +31,7 @@ final class KakaoLoginViewController: UIViewController {
 
 private extension KakaoLoginViewController {
     
-    private func isTokenVailed() {
+    func isTokenVailed() {
         if AuthApi.hasToken() {
             UserApi.shared.rx.accessTokenInfo()
                 .subscribe(onSuccess: { (_) in

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginViewModel.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/KakaoLoginViewModel.swift
@@ -1,0 +1,88 @@
+//
+//  KakaoLoginViewModel.swift
+//  Gom4ziz
+//
+//  Created by 이가은 on 2022/10/26.
+//
+
+import UIKit
+import RxSwift
+import KakaoSDKCommon
+import RxKakaoSDKCommon
+import KakaoSDKAuth
+import RxKakaoSDKAuth
+import KakaoSDKUser
+import RxKakaoSDKUser
+import RxCocoa
+
+final class KakaoLoginViewModel {
+    private let disposeBag: DisposeBag = DisposeBag()
+    let userInfo: PublishRelay<UserInfo> = .init()
+    let kakaoLoginstatus: PublishRelay<KakaoLoginstatus> = .init()
+    enum KakaoLoginstatus {
+        case login
+        case logout
+        case unlink
+    }
+    init() {
+    }
+    func loginWithKakao() {
+        if UserApi.isKakaoTalkLoginAvailable() {
+            UserApi.shared.rx.loginWithKakaoTalk()
+                .subscribe(onNext: { (oauthToken) in
+                    print("loginWithKakaoTalk() success.")
+                    self.getUserInfo()
+                    _ = oauthToken
+                }, onError: {error in
+                    print(error)
+                })
+                .disposed(by: self.disposeBag)
+        } else {
+            UserApi.shared.rx.loginWithKakaoAccount()
+                .subscribe(onNext: { (oauthToken) in
+                    print("loginWithKakaoAccount() success.")
+                    self.getUserInfo()
+                    _ = oauthToken
+                }, onError: {error in
+                    print(error)
+                })
+                .disposed(by: self.disposeBag)
+        }
+    }
+    func logout() {
+        UserApi.shared.rx.logout()
+            .subscribe(onCompleted: {
+                print("logout() success.")
+                self.userInfo.accept(UserInfo(id: UUID().uuidString, name: "로그아웃 성공", imageURL: nil))
+                self.kakaoLoginstatus.accept(.logout)
+            }, onError: { error in
+                print(error)
+            })
+            .disposed(by: disposeBag)
+    }
+    func unlink() {
+        UserApi.shared.rx.unlink()
+            .subscribe(onCompleted: {
+                print("unlink() success.")
+                self.userInfo.accept(UserInfo(id: UUID().uuidString, name: "회원 탈퇴 성공", imageURL: nil))
+                self.kakaoLoginstatus.accept(.unlink)
+            }, onError: {error in
+                print(error)
+            })
+            .disposed(by: disposeBag)
+    }
+    func getUserInfo() {
+        UserApi.shared.rx.me()
+            .subscribe(onSuccess: { user in
+                print("me() success.")
+                if let name = user.kakaoAccount?.profile?.nickname {
+                    self.userInfo.accept(UserInfo(id: UUID().uuidString, name: name, imageURL: user.kakaoAccount?.profile?.profileImageUrl))
+                }
+                self.kakaoLoginstatus.accept(.login)
+                _ = user
+            }, onFailure: {error in
+                print(error)
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/LoginManagerProtocol.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/LoginManagerProtocol.swift
@@ -1,0 +1,24 @@
+//
+//  LoginManagerProtocol.swift
+//  Gom4ziz
+//
+//  Created by 이가은 on 2022/10/27.
+//
+
+import Foundation
+import RxRelay
+
+enum KakaoLoginstatus {
+    case login
+    case logout
+    case unlink
+}
+
+protocol LoginManagerProtocol {
+    func login()
+    func logout()
+    func unlink()
+    func getUserInfo()
+    var userInfo: PublishRelay<UserInfo> { get }
+    var kakaoLoginstatus: PublishRelay<KakaoLoginstatus> { get }
+}

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/LoginManagerProtocol.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/LoginManagerProtocol.swift
@@ -8,7 +8,7 @@
 import Foundation
 import RxRelay
 
-enum KakaoLoginstatus {
+enum Loginstatus {
     case login
     case logout
     case unlink
@@ -20,5 +20,5 @@ protocol LoginManagerProtocol {
     func unlink()
     func getUserInfo()
     var userInfo: PublishRelay<UserInfo> { get }
-    var kakaoLoginstatus: PublishRelay<KakaoLoginstatus> { get }
+    var loginstatus: PublishRelay<Loginstatus> { get }
 }

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/LoginManagerProtocol.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/LoginManagerProtocol.swift
@@ -4,8 +4,8 @@
 //
 //  Created by 이가은 on 2022/10/27.
 //
-
 import Foundation
+
 import RxRelay
 
 enum Loginstatus {

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/LoginManagerProtocol.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/LoginManagerProtocol.swift
@@ -11,13 +11,13 @@ import RxRelay
 enum Loginstatus {
     case login
     case logout
-    case unlink
+    case withDrawal
 }
 
 protocol LoginManagerProtocol {
     func login()
     func logout()
-    func unlink()
+    func withDrawal()
     func getUserInfo()
     var userInfo: PublishRelay<UserInfo> { get }
     var loginstatus: PublishRelay<Loginstatus> { get }

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/LoginViewModel.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/LoginViewModel.swift
@@ -1,0 +1,32 @@
+//
+//  LoginViewModel.swift
+//  Gom4ziz
+//
+//  Created by 이가은 on 2022/10/26.
+//
+
+import UIKit
+
+final class LoginViewModel {
+    let loginManager: LoginManagerProtocol
+    
+    init(loginManager: LoginManagerProtocol) {
+        self.loginManager = loginManager
+    }
+    
+    func loginWithKakao() {
+        loginManager.login()
+    }
+    
+    func logout() {
+        loginManager.logout()
+    }
+    
+    func unlink() {
+        loginManager.unlink()
+    }
+    
+    func getUserInfo() {
+        loginManager.getUserInfo()
+    }
+}

--- a/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/LoginViewModel.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/kakaoLoginTest/LoginViewModel.swift
@@ -22,8 +22,8 @@ final class LoginViewModel {
         loginManager.logout()
     }
     
-    func unlink() {
-        loginManager.unlink()
+    func withDrawal() {
+        loginManager.withDrawal()
     }
     
     func getUserInfo() {

--- a/Gom4ziz/Gom4ziz/Resources/Base.lproj/Main.storyboard
+++ b/Gom4ziz/Gom4ziz/Resources/Base.lproj/Main.storyboard
@@ -1,24 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Gom4ziz" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="111" y="-2"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Gom4ziz/Gom4ziz/System/SceneDelegate.swift
+++ b/Gom4ziz/Gom4ziz/System/SceneDelegate.swift
@@ -11,50 +11,54 @@ import RxKakaoSDKAuth
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
     private let deeplinkHandler: DeeplinkHandler = .init()
-
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = scene as? UIWindowScene  else {
             return
         }
-
+        
         window = UIWindow(windowScene: windowScene)
         window?.makeKeyAndVisible()
 
         // 테스트를 위해서 루트 뷰컨트롤러를 변경할 수 있습니다.
         changeRootViewController(KakaoLoginViewController())
     }
-
+    
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         guard let url = URLContexts.first?.url else {
             return
+        }
+        print(URLContexts)
+        if AuthApi.isKakaoTalkLoginUrl(url) {
+            _ = AuthController.rx.handleOpenUrl(url: url)
         }
         deeplinkHandler.handle(url)
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {
     }
-
+    
     func sceneDidBecomeActive(_ scene: UIScene) {
     }
-
+    
     func sceneWillResignActive(_ scene: UIScene) {
-
+        
     }
-
+    
     func sceneWillEnterForeground(_ scene: UIScene) {
-
+        
     }
-
+    
     func sceneDidEnterBackground(_ scene: UIScene) {
-
+        
     }
 }
 
 private extension SceneDelegate {
-
+    
     /// 윈도우의 루트 뷰컨을 바꾸는 함수
     /// - Parameter controller: 바꿀 뷰컨트롤러
     func changeRootViewController(_ controller: UIViewController) {

--- a/Gom4ziz/Gom4ziz/System/SceneDelegate.swift
+++ b/Gom4ziz/Gom4ziz/System/SceneDelegate.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 import FirebaseAuth
+import RxKakaoSDKAuth
+import KakaoSDKAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -22,7 +24,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.makeKeyAndVisible()
 
         // 테스트를 위해서 루트 뷰컨트롤러를 변경할 수 있습니다.
-        changeRootViewController(AppleTestViewController())
+        changeRootViewController(KakaoLoginViewController())
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
@@ -31,7 +33,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
         deeplinkHandler.handle(url)
     }
-
+    
     func sceneDidDisconnect(_ scene: UIScene) {
     }
 

--- a/Gom4ziz/Gom4ziz/System/SceneDelegate.swift
+++ b/Gom4ziz/Gom4ziz/System/SceneDelegate.swift
@@ -5,10 +5,10 @@
 //  Created by JongHo Park on 2022/10/19.
 //
 
-import UIKit
 import FirebaseAuth
-import RxKakaoSDKAuth
 import KakaoSDKAuth
+import RxKakaoSDKAuth
+import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 


### PR DESCRIPTION
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.
🔒 Close #13

## 작업 내용 (Content)
- [x] 카카오 네이티브 앱 만들기
- [x] [카카오 로그인 모듈 설치](https://developers.kakao.com/docs/latest/ko/kakaologin/ios#before-you-begin-module)
- [x] 테스트 UI (로그인 후 계정 정보 표시, 로그아웃, 탈퇴)
- [x] 이전에 로그인 한 유저면 계정 정보 표시 UI
- [x] ViewController, ViewModel 역할 나누기
- [x] 호종이 카카오 네이티브 앱으로 변경하기 (제가 하나 만들어서 작업 중이었습니다...)

## Review points
- 리뷰어가 중점적으로 리뷰해줬으면 하는 포인트
[호종이 리뷰](https://github.com/DeveloperAcademy-POSTECH/MacC_Team_Beartear/pull/28)보고 ViewModel에서 도메인 로직을 구현하지 않고 Usecase(Manager)에 필요한 함수를 호출하도록 구조를 수정했습니다.
<img width="869" alt="스크린샷 2022-10-28 오전 9 51 55" src="https://user-images.githubusercontent.com/82457928/198424171-6160d890-ad13-4fb6-8c00-b48ded00a54d.png">


## 기타 사항 (Etc)
- 작업하면서 고민이 되었던 부분이나 질문 사항 등
- LoginManagerProtocol 프로퍼티에 다음과 같은 변수를 필요로 한다고 코드를 짜서 KakaoLoginManager에 해당 프로퍼티가 있는데, KakaoLoginManager가 아닌 ViewModel에 해당 값이 있어야 하는 건지 잘 모르겠습니다. 

```
    var userInfo: PublishRelay<UserInfo> { get }
    var loginstatus: PublishRelay<Loginstatus> { get }
```
- ~~@HoJongE 제가 카카오 네이티브 앱을 만들었었는데, 호종이께서 네이티브 앱을 만들어 팀원을 초대하셨더라구요! 그걸로 이동하겠습니다! 확인하시면 댓글 남겨주세요~~ -> 네이티브 앱 호종이 껄로 이동 후에 [세부 내용 설정](https://developers.kakao.com/console/app)했습니다.
- ~~로그인 시 사용자에게 Client가 "닉네임과 프로필 사진" 접근을 허용할 것인지 물어봅니다. 이 접근 허용 필수 선택으로 변경할까요?~~ -> 우선 선택 허용으로 두겠습니다.

## 관련 사진 gif 및 (Optional)
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/82457928/197446734-a4e9f022-e794-472a-9912-4374c825d3ab.gif)
- 1. 회원가입 시 사용자에게 "닉네임과 프로필 사진"의 접근 허용 구함 
- 2. 회원 탈퇴시 access token 날림 + 다시 회원가입 해야 함
- 3. 로그아웃 시 access token 날림 + 다시 로그인 해야 함
- 4. 로그인 후 앱 껐다 켜도 Client가 access token을 가지고 있기 때문에 "닉네임과 프로필 사진"에 접근 가능


## References (Optional)
- 참고한 사이트나 정리한 wiki 링크를 넣어주세요
- [OAuth2 개념에 대해 wiki에 정리해 뒀습니다.](https://github.com/DeveloperAcademy-POSTECH/MacC_Team_Beartear/discussions/22)
- [카카오 로그인 및 회원가입 등 개발자 문서](https://developers.kakao.com/docs/latest/ko/kakaologin/ios) 
