### PR TITLE
Feat/#14 apple login

### DIFF
--- a/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
+++ b/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
@@ -29,7 +29,6 @@
 		002821F329018E7700717E2C /* RxSwift+Firestore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821F229018E7700717E2C /* RxSwift+Firestore.swift */; };
 		002821F62901932A00717E2C /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 002821F52901932A00717E2C /* FirebaseFirestoreSwift */; };
 		002821F829022B2100717E2C /* UserInfoIdCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002821F729022B2100717E2C /* UserInfoIdCache.swift */; };
-		002821FA2902353400717E2C /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 002821F92902353400717E2C /* GoogleService-Info.plist */; };
 		003E5E5C2902D0FA004C597A /* RxBlocking in Frameworks */ = {isa = PBXBuildFile; productRef = 003E5E5B2902D0FA004C597A /* RxBlocking */; };
 		003E5E5E2902D0FA004C597A /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = 003E5E5D2902D0FA004C597A /* RxTest */; };
 		003E5E602902D1A6004C597A /* UserInfoRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003E5E5F2902D1A6004C597A /* UserInfoRepositoryTests.swift */; };
@@ -48,6 +47,7 @@
 		E63C75602909166200133C9E /* AppleTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C755F2909166200133C9E /* AppleTestView.swift */; };
 		E63C75622909166900133C9E /* AppleTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C75612909166900133C9E /* AppleTestViewController.swift */; };
 		E63C75642909171100133C9E /* AppleLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C75632909171100133C9E /* AppleLoginManager.swift */; };
+		E6F4878B290982AC00037CF9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */; };
 		F251F35C2903EDA5003B6690 /* PlansRoomListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */; };
 		F251F35F290549EF003B6690 /* PlansRoomRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F35E290549EF003B6690 /* PlansRoomRepository.swift */; };
 		F251F36329055245003B6690 /* PlansRoomRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F36229055245003B6690 /* PlansRoomRepositoryTests.swift */; };
@@ -78,7 +78,6 @@
 		002821F02901889000717E2C /* UserInfoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoRepository.swift; sourceTree = "<group>"; };
 		002821F229018E7700717E2C /* RxSwift+Firestore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RxSwift+Firestore.swift"; sourceTree = "<group>"; };
 		002821F729022B2100717E2C /* UserInfoIdCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoIdCache.swift; sourceTree = "<group>"; };
-		002821F92902353400717E2C /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		003E5E522902CF89004C597A /* Gom4zizTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Gom4zizTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		003E5E5F2902D1A6004C597A /* UserInfoRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoRepositoryTests.swift; sourceTree = "<group>"; };
 		0062EB782900222600B0A6AB /* Gom4ziz.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gom4ziz.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -98,6 +97,7 @@
 		E63C75612909166900133C9E /* AppleTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleTestViewController.swift; sourceTree = "<group>"; };
 		E63C75632909171100133C9E /* AppleLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginManager.swift; sourceTree = "<group>"; };
 		E63C75652909415900133C9E /* Gom4ziz.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Gom4ziz.entitlements; sourceTree = "<group>"; };
+		E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlansRoomListViewController.swift; path = Gom4ziz/Presenter/PlansRoomList/PlansRoomListViewController.swift; sourceTree = SOURCE_ROOT; };
 		F251F35E290549EF003B6690 /* PlansRoomRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlansRoomRepository.swift; sourceTree = "<group>"; };
 		F251F36229055245003B6690 /* PlansRoomRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlansRoomRepositoryTests.swift; sourceTree = "<group>"; };
@@ -205,7 +205,7 @@
 		0062EB6F2900222600B0A6AB = {
 			isa = PBXGroup;
 			children = (
-				002821F92902353400717E2C /* GoogleService-Info.plist */,
+				E6F4878A290982AC00037CF9 /* GoogleService-Info.plist */,
 				0062EBAC290023A600B0A6AB /* .swiftlint.yml */,
 				0062EB7A2900222600B0A6AB /* Gom4ziz */,
 				003E5E532902CF89004C597A /* Gom4zizTests */,
@@ -454,9 +454,9 @@
 			files = (
 				0062EBAD290023A600B0A6AB /* .swiftlint.yml in Resources */,
 				0062EB882900222700B0A6AB /* LaunchScreen.storyboard in Resources */,
-				002821FA2902353400717E2C /* GoogleService-Info.plist in Resources */,
 				0062EB852900222700B0A6AB /* Assets.xcassets in Resources */,
 				0062EB832900222600B0A6AB /* Main.storyboard in Resources */,
+				E6F4878B290982AC00037CF9 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
+++ b/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
@@ -45,6 +45,9 @@
 		00953D162909008C0022D6A4 /* JoinPlansRoomUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00953D152909008C0022D6A4 /* JoinPlansRoomUsecase.swift */; };
 		00A12CED290651980024934C /* DeeplinkParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A12CEC290651980024934C /* DeeplinkParserTests.swift */; };
 		E68685D1290FAB3100674CC4 /* KeyChainWrapper in Frameworks */ = {isa = PBXBuildFile; productRef = E68685D0290FAB3100674CC4 /* KeyChainWrapper */; };
+		E63C75602909166200133C9E /* AppleTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C755F2909166200133C9E /* AppleTestView.swift */; };
+		E63C75622909166900133C9E /* AppleTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C75612909166900133C9E /* AppleTestViewController.swift */; };
+		E63C75642909171100133C9E /* AppleLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63C75632909171100133C9E /* AppleLoginManager.swift */; };
 		F251F35C2903EDA5003B6690 /* PlansRoomListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */; };
 		F251F35F290549EF003B6690 /* PlansRoomRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F35E290549EF003B6690 /* PlansRoomRepository.swift */; };
 		F251F36329055245003B6690 /* PlansRoomRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251F36229055245003B6690 /* PlansRoomRepositoryTests.swift */; };
@@ -91,6 +94,9 @@
 		007EA01229062E4C000B8E31 /* DeeplinkParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkParser.swift; sourceTree = "<group>"; };
 		00953D152909008C0022D6A4 /* JoinPlansRoomUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinPlansRoomUsecase.swift; sourceTree = "<group>"; };
 		00A12CEC290651980024934C /* DeeplinkParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkParserTests.swift; sourceTree = "<group>"; };
+		E63C755F2909166200133C9E /* AppleTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleTestView.swift; sourceTree = "<group>"; };
+		E63C75612909166900133C9E /* AppleTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleTestViewController.swift; sourceTree = "<group>"; };
+		E63C75632909171100133C9E /* AppleLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginManager.swift; sourceTree = "<group>"; };
 		F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlansRoomListViewController.swift; path = Gom4ziz/Presenter/PlansRoomList/PlansRoomListViewController.swift; sourceTree = SOURCE_ROOT; };
 		F251F35E290549EF003B6690 /* PlansRoomRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlansRoomRepository.swift; sourceTree = "<group>"; };
 		F251F36229055245003B6690 /* PlansRoomRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlansRoomRepositoryTests.swift; sourceTree = "<group>"; };
@@ -173,6 +179,7 @@
 				001B1C7E2900FCC800F5C875 /* UserInfo.swift */,
 				001B1C802900FE5B00F5C875 /* PlansRoom.swift */,
 				001B1C822901049400F5C875 /* MockData.swift */,
+				E63C75632909171100133C9E /* AppleLoginManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -234,6 +241,7 @@
 		0062EBAE290024F500B0A6AB /* Presenter */ = {
 			isa = PBXGroup;
 			children = (
+				E63C755E2909162600133C9E /* AppleLoginTest */,
 				000A53132904F32500CEDACC /* ShareTest */,
 				F251F35D2903EDD6003B6690 /* PlansRoomList */,
 			);
@@ -314,6 +322,13 @@
 				00A12CEC290651980024934C /* DeeplinkParserTests.swift */,
 			);
 			path = System;
+		E63C755E2909162600133C9E /* AppleLoginTest */ = {
+			isa = PBXGroup;
+			children = (
+				E63C755F2909166200133C9E /* AppleTestView.swift */,
+				E63C75612909166900133C9E /* AppleTestViewController.swift */,
+			);
+			path = AppleLoginTest;
 			sourceTree = "<group>";
 		};
 		F251F35D2903EDD6003B6690 /* PlansRoomList */ = {
@@ -485,6 +500,8 @@
 				00953D162909008C0022D6A4 /* JoinPlansRoomUsecase.swift in Sources */,
 				001B1C832901049400F5C875 /* MockData.swift in Sources */,
 				F251F35C2903EDA5003B6690 /* PlansRoomListViewController.swift in Sources */,
+				E63C75602909166200133C9E /* AppleTestView.swift in Sources */,
+				E63C75642909171100133C9E /* AppleLoginManager.swift in Sources */,
 				002821EF2901884100717E2C /* ProcessInfo.swift in Sources */,
 				007EA00D2906290B000B8E31 /* DeeplinkHandler.swift in Sources */,
 				000A53152904F33800CEDACC /* ShareTestView.swift in Sources */,
@@ -500,6 +517,7 @@
 				007EA01329062E4C000B8E31 /* DeeplinkParser.swift in Sources */,
 				000A53122904F31A00CEDACC /* ShareTestViewController.swift in Sources */,
 				0062EB7E2900222600B0A6AB /* SceneDelegate.swift in Sources */,
+				E63C75622909166900133C9E /* AppleTestViewController.swift in Sources */,
 				000A53082904D85700CEDACC /* APIKey.swift in Sources */,
 				002821F329018E7700717E2C /* RxSwift+Firestore.swift in Sources */,
 				000A53172904F38800CEDACC /* SwiftUI+UIKit.swift in Sources */,
@@ -721,7 +739,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = team.gom4ziz.Gom4ziz;
+				PRODUCT_BUNDLE_IDENTIFIER = team.gom4ziz.Ziz4gom;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -751,7 +769,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = team.gom4ziz.Gom4ziz;
+				PRODUCT_BUNDLE_IDENTIFIER = team.gom4ziz.Ziz4gom;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
+++ b/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
@@ -324,6 +324,8 @@
 				00A12CEC290651980024934C /* DeeplinkParserTests.swift */,
 			);
 			path = System;
+            sourceTree = "<group>";
+        };
 		E63C755E2909162600133C9E /* AppleLoginTest */ = {
 			isa = PBXGroup;
 			children = (

--- a/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
+++ b/Gom4ziz/Gom4ziz.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		E63C755F2909166200133C9E /* AppleTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleTestView.swift; sourceTree = "<group>"; };
 		E63C75612909166900133C9E /* AppleTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleTestViewController.swift; sourceTree = "<group>"; };
 		E63C75632909171100133C9E /* AppleLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginManager.swift; sourceTree = "<group>"; };
+		E63C75652909415900133C9E /* Gom4ziz.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Gom4ziz.entitlements; sourceTree = "<group>"; };
 		F251F35B2903EDA5003B6690 /* PlansRoomListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlansRoomListViewController.swift; path = Gom4ziz/Presenter/PlansRoomList/PlansRoomListViewController.swift; sourceTree = SOURCE_ROOT; };
 		F251F35E290549EF003B6690 /* PlansRoomRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlansRoomRepository.swift; sourceTree = "<group>"; };
 		F251F36229055245003B6690 /* PlansRoomRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlansRoomRepositoryTests.swift; sourceTree = "<group>"; };
@@ -225,6 +226,7 @@
 		0062EB7A2900222600B0A6AB /* Gom4ziz */ = {
 			isa = PBXGroup;
 			children = (
+				E63C75652909415900133C9E /* Gom4ziz.entitlements */,
 				000A53092904DF8900CEDACC /* Service */,
 				000A53022904D7E900CEDACC /* Secret */,
 				0062EBB0290024FB00B0A6AB /* Data */,
@@ -723,10 +725,16 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Gom4ziz/Gom4ziz.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RS35G3C5;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 953VJTV7TA;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Gom4ziz/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -742,6 +750,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = team.gom4ziz.Ziz4gom;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = gom4ziz;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -753,10 +762,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Gom4ziz/Gom4ziz.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 953VJTV7TA;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Gom4ziz/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -772,6 +784,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = team.gom4ziz.Ziz4gom;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = gom4ziz;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Gom4ziz/Gom4ziz/Domain/Model/AppleLoginManager.swift
+++ b/Gom4ziz/Gom4ziz/Domain/Model/AppleLoginManager.swift
@@ -16,11 +16,11 @@ protocol AppleLoginManagerDelegate: AnyObject {
 
 final class AppleLoginManager: NSObject {
     private var currentNonce: String?
-    weak var viewController: UIViewController?
+    private weak var viewController: UIViewController?
     weak var delegate: AppleLoginManagerDelegate?
 
-    init(vc: UIViewController) {
-        self.viewController = vc
+    init(presentingViewController: UIViewController) {
+        self.viewController = presentingViewController
     }
 
     func startSignInWithAppleFlow() {

--- a/Gom4ziz/Gom4ziz/Domain/Model/AppleLoginManager.swift
+++ b/Gom4ziz/Gom4ziz/Domain/Model/AppleLoginManager.swift
@@ -1,0 +1,125 @@
+//
+//  AppleLoginManager.swift
+//  Gom4ziz
+//
+//  Created by sanghyo on 2022/10/26.
+//
+import AuthenticationServices
+import CryptoKit
+import FirebaseAuth
+
+protocol AppleLoginManagerDelegate: AnyObject {
+    func appleLoginSuccess() -> Void
+    func appleLoginFail() -> Void
+}
+
+final class AppleLoginManager: NSObject {
+    private var currentNonce: String?
+    weak var viewController: UIViewController?
+    weak var delegate: AppleLoginManagerDelegate?
+    
+    init(vc: UIViewController) {
+        self.viewController = vc
+    }
+    
+    func startSignInWithAppleFlow() {
+        let nonce = randomNonceString()
+        currentNonce = nonce
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = sha256(nonce)
+        
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        authorizationController.performRequests()
+    }
+    
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: [Character] =
+        Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0 ..< 16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError(
+                        "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
+                    )
+                }
+                return random
+            }
+
+            randoms.forEach { random in
+                if remainingLength == 0 {
+                    return
+                }
+
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+
+        return result
+    }
+    
+    private func sha256(_ input: String) -> String {
+      let inputData = Data(input.utf8)
+      let hashedData = SHA256.hash(data: inputData)
+      let hashString = hashedData.compactMap {
+        String(format: "%02x", $0)
+      }.joined()
+
+      return hashString
+    }
+}
+
+// MARK: - ASAuthorizationControllerDelegate
+
+extension AppleLoginManager: ASAuthorizationControllerDelegate {
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        if let appleIdCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            guard let nonce = currentNonce else {
+                fatalError("Invalid state: A login callback was received, but no login request was sent.")
+            }
+            guard let appleIDToken = appleIdCredential.identityToken else {
+                print("Unable to fetch identity token")
+                                return
+            }
+            guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+                print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
+                return
+            }
+            
+            let credential = OAuthProvider.credential(withProviderID: "apple.com",
+                                                      idToken: idTokenString,
+                                                            rawNonce: nonce)
+            Auth.auth().signIn(with: credential) { [self] authResult, error in
+                if let error = error {
+                    print ("Error Apple sign in: %@", error)
+                    return
+                }
+                delegate?.appleLoginSuccess()
+            }
+        }
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        delegate?.appleLoginFail()
+    }
+}
+
+// MARK: - ASAuthorizationControllerPresentationContextProviding
+
+extension AppleLoginManager: ASAuthorizationControllerPresentationContextProviding  {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return viewController!.view.window!
+    }
+}

--- a/Gom4ziz/Gom4ziz/Gom4ziz.entitlements
+++ b/Gom4ziz/Gom4ziz/Gom4ziz.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestView.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestView.swift
@@ -8,50 +8,39 @@ import AuthenticationServices
 import UIKit
 
 final class AppleTestView: UIView {
-    
+
     private (set) lazy var appleLoginButton = ASAuthorizationAppleIDButton()
     private (set) lazy var appleLogoutButton: UIButton = {
         var configuration: UIButton.Configuration = . filled()
-        var titleAttr = AttributedString.init("logout")
         let button = UIButton()
+        configuration.title = "로그아웃"
         button.configuration = configuration
         return button
     }()
     private let idLabel = UILabel()
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
+        backgroundColor = .systemBackground
         configureAddSubviews()
         configureConstraints()
     }
-    
+
     required init?(coder: NSCoder) {
-        super.init(coder: coder)
+        fatalError("No need to implement")
     }
-    
+
     // MARK: - addSubview
-    
+
     private func configureAddSubviews() {
         self.addSubview(appleLoginButton)
     }
-    
+
     private func configureConstraints() {
         appleLoginButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             appleLoginButton.centerXAnchor.constraint(equalTo: centerXAnchor),
             appleLoginButton.centerYAnchor.constraint(equalTo: centerYAnchor)
-        ])
-        
-        appleLogoutButton.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            appleLogoutButton.centerXAnchor.constraint(equalTo: centerXAnchor),
-            appleLogoutButton.centerYAnchor.constraint(equalTo: centerYAnchor)
-        ])
-        
-        idLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            idLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-            idLabel.bottomAnchor.constraint(equalTo: appleLoginButton.topAnchor, constant: -10)
         ])
     }
 }

--- a/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestView.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestView.swift
@@ -17,6 +17,13 @@ final class AppleTestView: UIView {
         button.configuration = configuration
         return button
     }()
+    private (set) lazy var appleWithdrawalButton: UIButton = {
+        var configuration: UIButton.Configuration = . filled()
+        let button = UIButton()
+        configuration.title = "탈퇴"
+        button.configuration = configuration
+        return button
+    }()
     private let idLabel = UILabel()
 
     override init(frame: CGRect) {
@@ -34,6 +41,8 @@ final class AppleTestView: UIView {
 
     private func configureAddSubviews() {
         self.addSubview(appleLoginButton)
+        self.addSubview(appleLogoutButton)
+        self.addSubview(appleWithdrawalButton)
     }
 
     private func configureConstraints() {
@@ -41,6 +50,18 @@ final class AppleTestView: UIView {
         NSLayoutConstraint.activate([
             appleLoginButton.centerXAnchor.constraint(equalTo: centerXAnchor),
             appleLoginButton.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+
+        appleLogoutButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            appleLogoutButton.centerXAnchor.constraint(equalTo: centerXAnchor),
+            appleLogoutButton.topAnchor.constraint(equalTo: appleLoginButton.bottomAnchor, constant: 30)
+        ])
+
+        appleWithdrawalButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            appleWithdrawalButton.centerXAnchor.constraint(equalTo: centerXAnchor),
+            appleWithdrawalButton.topAnchor.constraint(equalTo: appleLogoutButton.bottomAnchor, constant: 30)
         ])
     }
 }

--- a/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestView.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestView.swift
@@ -24,7 +24,6 @@ final class AppleTestView: UIView {
         button.configuration = configuration
         return button
     }()
-    private let idLabel = UILabel()
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestView.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestView.swift
@@ -1,0 +1,57 @@
+//
+//  AppleTestView.swift
+//  Gom4ziz
+//
+//  Created by sanghyo on 2022/10/26.
+//
+import AuthenticationServices
+import UIKit
+
+final class AppleTestView: UIView {
+    
+    private (set) lazy var appleLoginButton = ASAuthorizationAppleIDButton()
+    private (set) lazy var appleLogoutButton: UIButton = {
+        var configuration: UIButton.Configuration = . filled()
+        var titleAttr = AttributedString.init("logout")
+        let button = UIButton()
+        button.configuration = configuration
+        return button
+    }()
+    private let idLabel = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureAddSubviews()
+        configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    // MARK: - addSubview
+    
+    private func configureAddSubviews() {
+        self.addSubview(appleLoginButton)
+    }
+    
+    private func configureConstraints() {
+        appleLoginButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            appleLoginButton.centerXAnchor.constraint(equalTo: centerXAnchor),
+            appleLoginButton.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+        
+        appleLogoutButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            appleLogoutButton.centerXAnchor.constraint(equalTo: centerXAnchor),
+            appleLogoutButton.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+        
+        idLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            idLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            idLabel.bottomAnchor.constraint(equalTo: appleLoginButton.topAnchor, constant: -10)
+        ])
+    }
+}

--- a/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestViewController.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestViewController.swift
@@ -5,17 +5,13 @@
 //  Created by sanghyo on 2022/10/26.
 //
 
-import Foundation
 import UIKit
 
 import FirebaseAuth
 
 final class AppleTestViewController: UIViewController {
 
-    private lazy var appleLoginManager: AppleLoginManager = {
-        let manager = AppleLoginManager(vc: self)
-        return manager
-    }()
+    private lazy var appleLoginManager = AppleLoginManager(presentingViewController: self)
     private let appleTestView = AppleTestView()
 
     override func viewDidLoad() {

--- a/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestViewController.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestViewController.swift
@@ -9,8 +9,16 @@ import Foundation
 import UIKit
 
 final class AppleTestViewController: UIViewController {
-    
+
+    private lazy var appleLoginManager = AppleLoginManager(vc: self)
+    private let appleTestView = AppleTestView()
+
     override func viewDidLoad() {
-        <#code#>
+        super.viewDidLoad()
     }
+
+    override func loadView() {
+        self.view = appleTestView
+    }
+
 }

--- a/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestViewController.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestViewController.swift
@@ -8,6 +8,8 @@
 import Foundation
 import UIKit
 
+import FirebaseAuth
+
 final class AppleTestViewController: UIViewController {
 
     private lazy var appleLoginManager: AppleLoginManager = {
@@ -28,6 +30,8 @@ final class AppleTestViewController: UIViewController {
 
     private func bindingView() {
         appleTestView.appleLoginButton.addTarget(self, action: #selector(tapAppleLoginButton), for: .touchUpInside)
+        appleTestView.appleLogoutButton.addTarget(self, action: #selector(tapAppleLogoutButton), for: .touchUpInside)
+        appleTestView.appleWithdrawalButton.addTarget(self, action: #selector(tapAppleWithdrawalButton), for: .touchUpInside)
     }
 
     // MARK: - @objc function
@@ -35,10 +39,19 @@ final class AppleTestViewController: UIViewController {
     @objc private func tapAppleLoginButton() {
         appleLoginManager.startSignInWithAppleFlow()
     }
+
+    @objc private func tapAppleLogoutButton() {
+        appleLoginManager.signOut()
+    }
+
+    @objc private func tapAppleWithdrawalButton() {
+        appleLoginManager.withDrawal()
+    }
 }
 
 extension AppleTestViewController: AppleLoginManagerDelegate {
-    func appleLoginSuccess() {
+    func appleLoginSuccess(authResult: AuthDataResult?) {
+        // TODO: keychain 연동
         print("success")
     }
 

--- a/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestViewController.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestViewController.swift
@@ -10,15 +10,39 @@ import UIKit
 
 final class AppleTestViewController: UIViewController {
 
-    private lazy var appleLoginManager = AppleLoginManager(vc: self)
+    private lazy var appleLoginManager: AppleLoginManager = {
+        let manager = AppleLoginManager(vc: self)
+        return manager
+    }()
     private let appleTestView = AppleTestView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        appleLoginManager.delegate = self
+        bindingView()
     }
 
     override func loadView() {
         self.view = appleTestView
     }
 
+    private func bindingView() {
+        appleTestView.appleLoginButton.addTarget(self, action: #selector(tapAppleLoginButton), for: .touchUpInside)
+    }
+
+    // MARK: - @objc function
+
+    @objc private func tapAppleLoginButton() {
+        appleLoginManager.startSignInWithAppleFlow()
+    }
+}
+
+extension AppleTestViewController: AppleLoginManagerDelegate {
+    func appleLoginSuccess() {
+        print("success")
+    }
+
+    func appleLoginFail() {
+        print("fail")
+    }
 }

--- a/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestViewController.swift
+++ b/Gom4ziz/Gom4ziz/Presenter/AppleLoginTest/AppleTestViewController.swift
@@ -1,0 +1,16 @@
+//
+//  AppleTestViewController.swift
+//  Gom4ziz
+//
+//  Created by sanghyo on 2022/10/26.
+//
+
+import Foundation
+import UIKit
+
+final class AppleTestViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        <#code#>
+    }
+}

--- a/Gom4ziz/Gom4ziz/System/SceneDelegate.swift
+++ b/Gom4ziz/Gom4ziz/System/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         window?.makeKeyAndVisible()
         // 테스트를 위해서 루트 뷰컨트롤러를 변경할 수 있습니다.
-        changeRootViewController(ShareTestViewController())
+        changeRootViewController(AppleTestViewController())
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/Gom4ziz/Gom4ziz/System/SceneDelegate.swift
+++ b/Gom4ziz/Gom4ziz/System/SceneDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import FirebaseAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -19,6 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         window = UIWindow(windowScene: windowScene)
         window?.makeKeyAndVisible()
+
         // 테스트를 위해서 루트 뷰컨트롤러를 변경할 수 있습니다.
         changeRootViewController(AppleTestViewController())
     }

--- a/Gom4ziz/GoogleService-Info.plist
+++ b/Gom4ziz/GoogleService-Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CLIENT_ID</key>
-	<string>718965805636-i4ahv5pi4hfg4jmad4frrs7304cp4kbk.apps.googleusercontent.com</string>
+	<string>718965805636-pij3vtgm4483gl024bme51vhs8jrvf6t.apps.googleusercontent.com</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.718965805636-i4ahv5pi4hfg4jmad4frrs7304cp4kbk</string>
+	<string>com.googleusercontent.apps.718965805636-pij3vtgm4483gl024bme51vhs8jrvf6t</string>
 	<key>API_KEY</key>
 	<string>AIzaSyBOTn-lsFFirudCCHt5KESkkDKQFsszqWk</string>
 	<key>GCM_SENDER_ID</key>
@@ -13,7 +13,7 @@
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>team.gom4ziz.Gom4ziz</string>
+	<string>team.gom4ziz.Ziz4gom</string>
 	<key>PROJECT_ID</key>
 	<string>gom4ziz</string>
 	<key>STORAGE_BUCKET</key>
@@ -29,6 +29,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:718965805636:ios:a6535b11cda6ac95ee2211</string>
+	<string>1:718965805636:ios:a722b25d95a9d1bfee2211</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.
🔒 Close #14

## 작업 내용 (Content)
- [x] 프로젝트 signing 추가
- [x] certificates에 id 등록, apple developer에서 firebase 도메인 입력
- [x] apple 로그인 담당 객체 생성하여 로직 구성
- [x] 테스트 UI (로그인 버튼, 로그아웃 버튼, 탈퇴 버튼, 로그인 이후 계정 정보 표시 UI)
- [x] 팀 provisioning profile 

## Review points
- addSubview, layout등의 작업을 하는 함수명이 제각각 달라서 통일하면 좋을 것 같습니다
- apple login 모달 때문에 apple login manager에 viewController를 주입해줬습니다. 이 과정에서 순환 참조 발생이 우려되어 vc를 약한 참조하였습니다.
- ASAuthorizationControllerPresentationContextProviding은 apple login 모달을 어느 window에서 띄울지 결정하는 곳입니다.
아래와 같이 force unwrapping을 하였는데 공식문서에서도 이렇게 진행했고 제 판단에도 viewController가 존재하지 않을 수는 없다고 생각하여 force하게 하였습니다. 혹시나 우려되는 사항이 있거나 다른 방안이 있으면 조언 부탁드립니다
```swift
return viewController!.view.window!
```


## 기타 사항 (Etc)
- Rx로 구현은 조금 더 공부한 뒤에 구현하도록 하겠습니다
- 현재는 로그인, 로그아웃, 탈퇴 기능만 구현하였고 자동 로그인 관련 기능은 추후 구현하겠습니다. 이와 관련하여 고민한 내용은 discussion에 올리겠습니다
- issue #30에서 추후 구현할 사항들을 정리했습니다

## 관련 사진 gif 및 (Optional)

## References (Optional)
- [provisioning profile](https://rriver2.tistory.com/entry/협업할-때-Certificate-Provisioning-Profiles-개념-실습)
- [apple login 브랜디](https://labs.brandi.co.kr/2021/04/09/chosh.html)
- [apple login 공식 문서](https://developer.apple.com/documentation/authenticationservices/implementing_user_authentication_with_sign_in_with_apple)
- [apple login과 firebase](https://firebase.google.com/docs/auth/ios/apple)
