### PR TITLE
Feat: artwork 요청에 대한 상태를 나타내기 위한 데이터타입을 정의하였습니다.

### DIFF
--- a/Gom4ziz/Source/Presenter/WeeklyArtworkStatus.swift
+++ b/Gom4ziz/Source/Presenter/WeeklyArtworkStatus.swift
@@ -1,0 +1,33 @@
+//
+//  WeeklyArtworkStatus.swift
+//  Gom4ziz
+//
+//  Created by sanghyo on 2022/11/21.
+//
+
+import Foundation
+
+enum WeeklyArtworkStatus {
+    case notRequested
+    case loading(last: Artwork?)
+    case loaded(Artwork)
+    case noMoreData
+    case failed(Error)
+}
+
+extension WeeklyArtworkStatus: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .notRequested:
+            return "아직 요청되지 않음"
+        case .loading(let last):
+            return "로딩중임. 이전 데이터 \(String(describing: last))"
+        case .loaded(let data):
+            return "\(data) 로드 완료"
+        case .noMoreData:
+            return "더이상 받을 데이터가 없음. 다음 데이터 받는 날 까지 기다려야함"
+        case .failed(let error):
+            return "\(error) 종류의 에러 발생 "
+        }
+    }
+}


### PR DESCRIPTION
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.
🔒 Close #65

## 작업 내용 (Content)
기존의 Loadable로는 artwork 요청에 대한 상태를 나타내지 못하는 경우가 있어 새로운 데이터타입을 정의하였습니다.
ex. 모든 질문들에 답하여 이번주 토요일까지 받아올 artwork가 없는 경우

앱 내의 다양한 경우에서 artwork를 불러올 일이 있을 것으로 보이나, 이러한 artwork 요청에 대한 특이한 상태는 질문관련 로직 구현에만 사용될 것 이라는 판단이 들었습니다.
그래서 enum을 generic으로 만들지 않고 WeeklyArtworkStatus 라고 명명했습니다.

## Review points
- 리뷰어가 중점적으로 리뷰해줬으면 하는 포인트

## 기타 사항 (Etc)
- 작업하면서 고민이 되었던 부분이나 질문 사항 등

## 관련 사진 gif 및 (Optional)

## References (Optional)
- 참고한 사이트나 정리한 wiki 링크를 넣어주세요
- [링크이름](링크)
