### PR TITLE
Feature #67 ArtworkReview를 추가하는 기능을 구현했습니다.

### DIFF
--- a/Gom4ziz/Source/Data/FirebaseArtworkRepository.swift
+++ b/Gom4ziz/Source/Data/FirebaseArtworkRepository.swift
@@ -19,9 +19,7 @@ final class FirebaseArtworkRepository: ArtworkRepository {
     static let shared: ArtworkRepository = FirebaseArtworkRepository()
     private let db: Firestore = Firestore.firestore()
     private let collectionName: String = CollectionName.artwork
-    
-    private init() { }
-    
+        
     func requestArtwork(of artworkId: String) -> Observable<Artwork> {
         getArtworkRef(of: artworkId)
             .rx
@@ -29,8 +27,10 @@ final class FirebaseArtworkRepository: ArtworkRepository {
     }
 }
 
-private extension FirebaseArtworkRepository {
+extension FirebaseArtworkRepository {
     func getArtworkRef(of artworkId: String) -> DocumentReference {
-        db.collection(collectionName).document(artworkId)
+        db
+            .collection(collectionName)
+            .document(artworkId)
     }
 }

--- a/Gom4ziz/Source/Data/Repository/FirebaseArtworkReviewRepository.swift
+++ b/Gom4ziz/Source/Data/Repository/FirebaseArtworkReviewRepository.swift
@@ -17,10 +17,8 @@ protocol ArtworkReviewRepository {
 }
 
 final class FirebaseArtworkReviewRepository {
-    static let shared: ArtworkReviewRepository = FirebaseArtworkReviewRepository()
+    static let shared: FirebaseArtworkReviewRepository = FirebaseArtworkReviewRepository()
     private let db: Firestore = Firestore.firestore()
-    
-    private init() { }
 }
 
 extension FirebaseArtworkReviewRepository: ArtworkReviewRepository {
@@ -32,7 +30,8 @@ extension FirebaseArtworkReviewRepository: ArtworkReviewRepository {
     }
 
     func addArtworkReview(of artworkId: Int, _ artworkReview: ArtworkReview) -> Single<Void> {
-        db.rx
+        db
+            .rx
             .runTransaction { [self] (transaction, errorPointer) -> Void? in
                 do {
                     // artworkReview를 추가한다.
@@ -53,14 +52,18 @@ extension FirebaseArtworkReviewRepository: ArtworkReviewRepository {
     }
 }
 
-private extension FirebaseArtworkReviewRepository {
+extension FirebaseArtworkReviewRepository {
     func getArtworkReviewRef(of artworkId: Int, _ userId: String) -> DocumentReference {
-        db.collection(CollectionName.artwork).document("\(artworkId)")
-            .collection(CollectionName.artworkReview).document(userId)
+        db
+            .collection(CollectionName.artwork)
+            .document("\(artworkId)")
+            .collection(CollectionName.artworkReview)
+            .document(userId)
     }
 
     func getUserRef(of uid: String) -> DocumentReference {
-        db.collection(CollectionName.user)
+        db
+            .collection(CollectionName.user)
             .document(uid)
     }
 }

--- a/Gom4ziz/Source/Data/Repository/FirebaseArtworkReviewRepository.swift
+++ b/Gom4ziz/Source/Data/Repository/FirebaseArtworkReviewRepository.swift
@@ -13,6 +13,7 @@ import RxRelay
 
 protocol ArtworkReviewRepository {
     func fetchArtworkReview(of artworkId: Int, _ userId: String) -> Observable<ArtworkReview>
+    func addArtworkReview(of artworkId: Int, _ artworkReview: ArtworkReview) -> Single<Void>
 }
 
 final class FirebaseArtworkReviewRepository {
@@ -23,10 +24,32 @@ final class FirebaseArtworkReviewRepository {
 }
 
 extension FirebaseArtworkReviewRepository: ArtworkReviewRepository {
+
     func fetchArtworkReview(of artworkId: Int, _ userId: String) -> Observable<ArtworkReview> {
         getArtworkReviewRef(of: artworkId, userId)
             .rx
             .decodable(as: ArtworkReview.self)
+    }
+
+    func addArtworkReview(of artworkId: Int, _ artworkReview: ArtworkReview) -> Single<Void> {
+        db.rx
+            .runTransaction { [self] (transaction, errorPointer) -> Void? in
+                do {
+                    // artworkReview를 추가한다.
+                    let artworkReviewRef: DocumentReference = getArtworkReviewRef(of: artworkId, artworkReview.uid)
+                    try transaction.setData(from: artworkReview, forDocument: artworkReviewRef)
+
+                    // user의 최신 artworkReview id를 갱신한다.
+                    transaction.updateData([
+                        "lastArtworkId": artworkId
+                    ], forDocument: getUserRef(of: artworkReview.uid))
+                    return nil
+                } catch {
+                    let nsError = error as NSError
+                    errorPointer?.pointee = nsError
+                    return nil
+                }
+            }
     }
 }
 
@@ -34,5 +57,10 @@ private extension FirebaseArtworkReviewRepository {
     func getArtworkReviewRef(of artworkId: Int, _ userId: String) -> DocumentReference {
         db.collection(CollectionName.artwork).document("\(artworkId)")
             .collection(CollectionName.artworkReview).document(userId)
+    }
+
+    func getUserRef(of uid: String) -> DocumentReference {
+        db.collection(CollectionName.user)
+            .document(uid)
     }
 }

--- a/Gom4ziz/Source/Domain/Model/MockData.swift
+++ b/Gom4ziz/Source/Domain/Model/MockData.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 extension User {
-    var mockData: User {
+    static var mockData: User {
         User(id: "mock", lastArtworkId: 5)
     }
 }
@@ -55,7 +55,7 @@ extension Artwork {
 }
 
 extension ArtworkReview {
-    var mockData: ArtworkReview {
+    static var mockData: ArtworkReview {
         ArtworkReview(id: "mock",
                       questionAnswer: "저에게 있어 운동이란 마약과도 같죠",
                       review: "정말 운동에 미친 사람이구나",
@@ -65,7 +65,7 @@ extension ArtworkReview {
 }
 
 extension ArtworkDescription {
-    var mockData: ArtworkDescription {
+    static var mockData: ArtworkDescription {
         ArtworkDescription(id: 1,
                            content: """
                            운동에 미친 사람은 어떤 사람일까?운동에 미친 사람은 어떤 사람일까?운동에 미친 사람은 어떤 사람일까?

--- a/Gom4ziz/Source/Extension/RxSwift+Firestore.swift
+++ b/Gom4ziz/Source/Extension/RxSwift+Firestore.swift
@@ -104,3 +104,19 @@ extension Reactive where Base: DocumentReference {
         }
     }
 }
+
+extension Reactive where Base: Firestore {
+    func runTransaction(updateBlock: @escaping (Transaction, NSErrorPointer) -> Any?) -> Single<Void> {
+        Single.create { single -> Disposable in
+            base.runTransaction(updateBlock) { _, error in
+                if let error {
+                    single(.failure(error))
+                    return
+                }
+                single(.success(()))
+            }
+
+            return Disposables.create()
+        }
+    }
+}

--- a/Gom4zizTests/Source/ArtworkReviewRepositoryTests.swift
+++ b/Gom4zizTests/Source/ArtworkReviewRepositoryTests.swift
@@ -1,0 +1,45 @@
+//
+//  ArtworkReviewRepositoryTests.swift
+//  Gom4zizTests
+//
+//  Created by JongHo Park on 2022/11/21.
+//
+
+@testable import Gom4ziz
+import XCTest
+
+import RxTest
+import RxBlocking
+
+final class ArtworkReviewRepositoryTests: XCTestCase {
+
+    private var artworkReviewRepository: FirebaseArtworkReviewRepository!
+    private var artworkRepository: FirebaseArtworkRepository!
+    private let testArtwork: Artwork = Artwork.mockData
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        artworkRepository = FirebaseArtworkRepository()
+        artworkReviewRepository = FirebaseArtworkReviewRepository()
+        try artworkRepository.addArtwork(artwork: testArtwork).toBlocking().last()
+    }
+
+    override func tearDownWithError() throws {
+        try artworkRepository.deleteArtwork(artwork: testArtwork).toBlocking().last()
+        artworkReviewRepository = nil
+        artworkRepository = nil
+        try super.tearDownWithError()
+    }
+
+    // TODO: 유저를 추가한 뒤 테스트를 진행해야함!
+    func test_아트워크리뷰를_정상적으로_등록하는지() throws {
+        // given
+        let review: ArtworkReview = .mockData
+        // when
+        try artworkReviewRepository.addArtworkReview(of: testArtwork.id, review).toBlocking().last()
+        let loadedReview = try artworkReviewRepository.fetchArtworkReview(of: testArtwork.id, review.uid).toBlocking().first()
+        // then
+        XCTAssertEqual(loadedReview, review)
+        try artworkReviewRepository.deleteArtworkReview(of: testArtwork.id, review: review).toBlocking().last()
+    }
+}

--- a/Gom4zizTests/Source/Extension/FirebaseArtworkRepositoryExtension.swift
+++ b/Gom4zizTests/Source/Extension/FirebaseArtworkRepositoryExtension.swift
@@ -1,0 +1,24 @@
+//
+//  FirebaseArtworkRepositoryTests.swift
+//  Gom4ziz
+//
+//  Created by JongHo Park on 2022/11/21.
+//
+
+@testable import Gom4ziz
+
+import RxSwift
+
+extension FirebaseArtworkRepository {
+
+    func addArtwork(artwork: Artwork) -> Single<Void> {
+        getArtworkRef(of: String(artwork.id))
+            .rx
+            .setData(artwork)
+    }
+    func deleteArtwork(artwork: Artwork) -> Single<Void> {
+        getArtworkRef(of: String(artwork.id))
+            .rx
+            .deleteDocument()
+    }
+}

--- a/Gom4zizTests/Source/Extension/FirebaseArtworkReviewRepositoryExtension.swift
+++ b/Gom4zizTests/Source/Extension/FirebaseArtworkReviewRepositoryExtension.swift
@@ -1,0 +1,18 @@
+//
+//  FirebaseArtworkReviewRepositoryExtension.swift
+//  Gom4ziz
+//
+//  Created by JongHo Park on 2022/11/21.
+//
+
+@testable import Gom4ziz
+
+import RxSwift
+
+extension FirebaseArtworkReviewRepository {
+    func deleteArtworkReview(of artworkId: Int, review: ArtworkReview) -> Single<Void> {
+        getArtworkReviewRef(of: artworkId, review.uid)
+            .rx
+            .deleteDocument()
+    }
+}


### PR DESCRIPTION
## Close Issues
🔒 Close #67 

## 작업 내용 (Content)
- [Firebase Transaction의 Rx Extension을 추가하였습니다.](https://github.com/DeveloperAcademy-POSTECH/MacC_Team_Beartear/compare/develop...DeveloperAcademy-POSTECH:Feature%2F%2367_add_artworkReview?expand=1#diff-b8e8eca85dc0baa2c703fb72f3b5f16258cd7cc0a98f11929f97f515d1156011R108-R122)
- [Transaction을 사용하여, artworkReview와 user의 lastArtworkId 속성을 업데이트 하는 기능을 구현했습니다.](https://github.com/DeveloperAcademy-POSTECH/MacC_Team_Beartear/compare/develop...DeveloperAcademy-POSTECH:Feature%2F%2367_add_artworkReview?expand=1#diff-a1330d7a1fd82d706abb958f4b14dce494bc60c271ef1112fefc408dec87fce0R32-R53)
- [ArtworkReviewRepository Test를 쉽게 하기 위한 extension 코드들을 Test target에 추가하였습니다.실제 프로덕트에서는 artwork를 가내수공업으로 제작하므로, artwork를추가, 삭제하는 코드를 추가했습니다.](https://github.com/DeveloperAcademy-POSTECH/MacC_Team_Beartear/compare/develop...DeveloperAcademy-POSTECH:Feature%2F%2367_add_artworkReview?expand=1#diff-8dd183f1ab0ca6c7deb330341a3dfcf57361cdfb4963ba3b68d052d149f2dac9R12-R24)

## Review points
- 실질적인 테스트는, User 등록 기능이 추가된 후 가능합니다.

## References (Optional)
- [Firebase transaction](https://firebase.google.com/docs/firestore/manage-data/transactions?hl=ko&authuser=0)
