### PR TITLE
Feature: #60 ArtworkReview를 불러오는 Domain 로직을 추가했습니다.

### DIFF
--- a/Gom4ziz/Source/Domain/Model/MockData.swift
+++ b/Gom4ziz/Source/Domain/Model/MockData.swift
@@ -15,7 +15,7 @@ extension User {
 }
 
 extension Artwork {
-    var mockData: Artwork {
+    static var mockData: Artwork {
         Artwork(id: 1,
                 imageUrl: "",
                 question: "당신에게 있어서 방주란 무엇인가요?",
@@ -55,7 +55,7 @@ extension Artwork {
 }
 
 extension ArtworkReview {
-    var mockData: ArtworkReview {
+    static var mockData: ArtworkReview {
         ArtworkReview(id: "mock",
                       questionAnswer: "저에게 있어 운동이란 마약과도 같죠",
                       review: "정말 운동에 미친 사람이구나",

--- a/Gom4ziz/Source/Domain/UseCase/FetchArtworkReviewUseCase.swift
+++ b/Gom4ziz/Source/Domain/UseCase/FetchArtworkReviewUseCase.swift
@@ -1,0 +1,26 @@
+//
+//  FetchArtworkReviewUsecase.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/11/21.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol FetchArtworkReviewUseCase {
+    func fetchArtwokReview(of artworkId: Int, _ userId: String) -> Observable<ArtworkReview>
+}
+
+struct RealFetchArtworkReviewUseCase: FetchArtworkReviewUseCase {
+    private let artworkReviewRepository: ArtworkReviewRepository
+    
+    init(artworkReviewRepository: ArtworkReviewRepository = FirebaseArtworkReviewRepository.shared) {
+        self.artworkReviewRepository = artworkReviewRepository
+    }
+    
+    func fetchArtwokReview(of artworkId: Int, _ userId: String) -> Observable<ArtworkReview> {
+        artworkReviewRepository.fetchArtworkReview(of: artworkId, userId)
+    }
+}

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewModel.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewModel.swift
@@ -12,7 +12,7 @@ import RxSwift
 
 final class MyFeedViewModel {
     private let fetchArtworkReviewUseCase: FetchArtworkReviewUseCase
-    let artworkReview: BehaviorRelay<Loadable<ArtworkReview>> = .init(value: .isLoading(last: nil))
+    let artworkReview: BehaviorRelay<Loadable<ArtworkReview>> = .init(value: .notRequested)
     private let disposeBag: DisposeBag = .init()
     
     init(fetchArtworkReviewUseCase: FetchArtworkReviewUseCase) {
@@ -20,6 +20,7 @@ final class MyFeedViewModel {
     }
     
     func fetchArtworkReview(of artworkId: Int, _ userId: String) {
+        artworkReview.accept(.isLoading(last: nil))
         fetchArtworkReviewUseCase.fetchArtwokReview(of: artworkId, userId)
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] in

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewModel.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewModel.swift
@@ -1,0 +1,32 @@
+//
+//  MyFeedViewModel.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/11/21.
+//
+
+import Foundation
+
+import RxCocoa
+import RxSwift
+
+final class MyFeedViewModel {
+    private let fetchArtworkReviewUseCase: FetchArtworkReviewUseCase
+    let artworkReview: BehaviorRelay<Loadable<ArtworkReview>> = .init(value: .isLoading(last: nil))
+    private let disposeBag: DisposeBag = .init()
+    
+    init(fetchArtworkReviewUseCase: FetchArtworkReviewUseCase) {
+        self.fetchArtworkReviewUseCase = fetchArtworkReviewUseCase
+    }
+    
+    func fetchArtworkReview(of artworkId: Int, _ userId: String) {
+        fetchArtworkReviewUseCase.fetchArtwokReview(of: artworkId, userId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] in
+                self?.artworkReview.accept(.loaded($0))
+            }, onError: { [weak self] in
+                self?.artworkReview.accept(.failed($0))
+            })
+            .disposed(by: disposeBag)
+    }
+}


### PR DESCRIPTION
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.
🔒 Close #60 

## 작업 내용 (Content)
- <img width="674" alt="Screenshot 2022-11-21 at 20 30 26" src="https://user-images.githubusercontent.com/59136391/203040191-2ccb7f77-6e98-4316-8a16-a910e241e31f.png">
- <img width="591" alt="Screenshot 2022-11-21 at 20 30 00" src="https://user-images.githubusercontent.com/59136391/203039990-2a28d7a4-0ca3-4fb1-8135-88c817d5d072.png">


- ArtworkReview를 불러오는 Domain Logic에 필요한 ArtworkReviewRepository를 의존하는 UseCase 모델을 만들었습니다.
- ArtworkReview를 불러오는 UseCase 모델을 가지는 MyFeedViewModel을 만들었습니다.
- 데이터 요청의 결과에 따른 UI 업데이트를 위해 Loadable로 ArtworkReview를 wrapping 하여 분기처리했습니다.
  - 해당 페이지는 무조건 유저의 접근이 필요합니다. BehaviorRelay를 사용해서 초기값을 `.isLoading(last: nil)`로 설정했고, `fetchArtworkReview`를 호출해서 데이터 요청 결과에 따라 `.loaded`, `.failed`로 나누었습니다.


## Review points
- 리뷰어가 중점적으로 리뷰해줬으면 하는 포인트
- MyFeedViewModel에서 데이터 요청 결과에 따라 Loadable<ArtworkReview>를 분기처리 했습니다.

## 기타 사항 (Etc)
- 작업하면서 고민이 되었던 부분이나 질문 사항 등

## 관련 사진 gif 및 (Optional)

## References (Optional)
- 참고한 사이트나 정리한 wiki 링크를 넣어주세요
- [링크이름](링크)
