### PR TITLE
[Feature] #85 Highlight를 불러오는 Domain 로직을 추가했습니다.

### DIFF
--- a/Gom4ziz/Source/Domain/UseCase/FetchHighlightUseCase.swift
+++ b/Gom4ziz/Source/Domain/UseCase/FetchHighlightUseCase.swift
@@ -1,0 +1,26 @@
+//
+//  FetchHighlightUseCase.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/11/22.
+//
+
+import Foundation
+
+import RxSwift
+
+protocol FetchHighlightUseCase {
+    func fetchHighlight(of artworkId: Int, _ userId: String) -> Observable<[Highlight]>
+}
+
+struct RealFetchHighlightUseCase: FetchHighlightUseCase {
+    private let highlightRepository: HighlightRepository
+    
+    init(highlightRepository: HighlightRepository = FirebaseHighlightRepository.shared) {
+        self.highlightRepository = highlightRepository
+    }
+    
+    func fetchHighlight(of artworkId: Int, _ userId: String) -> Observable<[Highlight]> {
+        highlightRepository.fetchHighlight(of: artworkId, userId)
+    }
+}

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewModel.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewModel.swift
@@ -14,13 +14,18 @@ final class MyFeedViewModel {
     
     private let fetchArtworkReviewUseCase: FetchArtworkReviewUseCase
     private let fetchArtworkDescriptionUseCase: FetchArtworkDescriptionUseCase
+    private let fetchHighlightUseCase: FetchHighlightUseCase
     let artworkReview: BehaviorRelay<Loadable<ArtworkReview>> = .init(value: .notRequested)
     let artworkDescription: BehaviorRelay<Loadable<ArtworkDescription>> = .init(value: .notRequested)
+    let highlights: BehaviorRelay<Loadable<[Highlight]>> = .init(value: .notRequested)
     private let disposeBag: DisposeBag = .init()
     
-    init(fetchArtworkReviewUseCase: FetchArtworkReviewUseCase, fetchArtworkDescriptionUseCase: FetchArtworkDescriptionUseCase) {
+    init(fetchArtworkReviewUseCase: FetchArtworkReviewUseCase,
+         fetchArtworkDescriptionUseCase: FetchArtworkDescriptionUseCase,
+         fetchHighlightUseCase: FetchHighlightUseCase) {
         self.fetchArtworkReviewUseCase = fetchArtworkReviewUseCase
         self.fetchArtworkDescriptionUseCase = fetchArtworkDescriptionUseCase
+        self.fetchHighlightUseCase = fetchHighlightUseCase
     }
     
     func fetchArtworkReview(of artworkId: Int, _ userId: String) {
@@ -43,6 +48,18 @@ final class MyFeedViewModel {
                 self?.artworkDescription.accept(.loaded($0))
             }, onError: { [weak self] in
                 self?.artworkDescription.accept(.failed($0))
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func fetchHighlight(of artworkId: Int, _ userId: String) {
+        highlights.accept(.isLoading(last: nil))
+        fetchHighlightUseCase.fetchHighlight(of: artworkId, userId)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] in
+                self?.highlights.accept(.loaded($0))
+            }, onError: { [weak self] in
+                self?.highlights.accept(.failed($0))
             })
             .disposed(by: disposeBag)
     }

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewModel.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewModel.swift
@@ -15,9 +15,9 @@ final class MyFeedViewModel {
     private let fetchArtworkReviewUseCase: FetchArtworkReviewUseCase
     private let fetchArtworkDescriptionUseCase: FetchArtworkDescriptionUseCase
     private let fetchHighlightUseCase: FetchHighlightUseCase
-    let artworkReview: BehaviorRelay<Loadable<ArtworkReview>> = .init(value: .notRequested)
-    let artworkDescription: BehaviorRelay<Loadable<ArtworkDescription>> = .init(value: .notRequested)
-    let highlights: BehaviorRelay<Loadable<[Highlight]>> = .init(value: .notRequested)
+    let artworkReviewObservable: BehaviorRelay<Loadable<ArtworkReview>> = .init(value: .notRequested)
+    let artworkDescriptionObservable: BehaviorRelay<Loadable<ArtworkDescription>> = .init(value: .notRequested)
+    let highlightObservable: BehaviorRelay<Loadable<[Highlight]>> = .init(value: .notRequested)
     private let disposeBag: DisposeBag = .init()
     
     init(fetchArtworkReviewUseCase: FetchArtworkReviewUseCase,
@@ -29,37 +29,37 @@ final class MyFeedViewModel {
     }
     
     func fetchArtworkReview(of artworkId: Int, _ userId: String) {
-        artworkReview.accept(.isLoading(last: nil))
+        artworkReviewObservable.accept(.isLoading(last: nil))
         fetchArtworkReviewUseCase.fetchArtwokReview(of: artworkId, userId)
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] in
-                self?.artworkReview.accept(.loaded($0))
+                self?.artworkReviewObservable.accept(.loaded($0))
             }, onError: { [weak self] in
-                self?.artworkReview.accept(.failed($0))
+                self?.artworkReviewObservable.accept(.failed($0))
             })
             .disposed(by: disposeBag)
     }
     
     func fetchArtworkDescription(of artworkId: Int) {
-        artworkDescription.accept(.isLoading(last: nil))
+        artworkDescriptionObservable.accept(.isLoading(last: nil))
         fetchArtworkDescriptionUseCase.fetchArtworkDescription(of: artworkId)
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] in
-                self?.artworkDescription.accept(.loaded($0))
+                self?.artworkDescriptionObservable.accept(.loaded($0))
             }, onError: { [weak self] in
-                self?.artworkDescription.accept(.failed($0))
+                self?.artworkDescriptionObservable.accept(.failed($0))
             })
             .disposed(by: disposeBag)
     }
     
     func fetchHighlight(of artworkId: Int, _ userId: String) {
-        highlights.accept(.isLoading(last: nil))
+        highlightObservable.accept(.isLoading(last: nil))
         fetchHighlightUseCase.fetchHighlight(of: artworkId, userId)
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] in
-                self?.highlights.accept(.loaded($0))
+                self?.highlightObservable.accept(.loaded($0))
             }, onError: { [weak self] in
-                self?.highlights.accept(.failed($0))
+                self?.highlightObservable.accept(.failed($0))
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.
🔒 Close #85 

## 작업 내용 (Content)
<img width="483" alt="Screenshot 2022-11-22 at 16 26 07" src="https://user-images.githubusercontent.com/59136391/203254160-0562ad0f-159d-4114-b05b-aacf9ffc5989.png">
<img width="403" alt="Screenshot 2022-11-22 at 16 42 05" src="https://user-images.githubusercontent.com/59136391/203254365-d891a710-871e-46c9-8f35-2614a5d02437.png">

- Highlight를 불러오는 Domain Logic에 필요한 Highlight Repository를 의존하는 UseCase 모델을 만들었습니다.
- Highlight를 불러오는 UseCase 모델을 가지는 MyFeedViewModel을 만들었습니다.
- 데이터 요청의 결과에 따른 UI 업데이트를 위해 Loadable로 Highlight를 wrapping 하여 분기처리했습니다.
  - 해당 페이지는 무조건 유저의 접근이 필요합니다. BehaviorRelay를 사용해서 초기값을 .notRequested로 설정했고, fetchHighlight를 호출하면 .isLoading(last: nil)로 변견되고 데이터 요청 결과에 따라 .loaded, .failed로 나누었습니다.

## Review points
- 리뷰어가 중점적으로 리뷰해줬으면 하는 포인트

## 기타 사항 (Etc)
- 작업하면서 고민이 되었던 부분이나 질문 사항 등

## 관련 사진 gif 및 (Optional)

## References (Optional)
- 참고한 사이트나 정리한 wiki 링크를 넣어주세요
- [링크이름](링크)
