### PR TITLE
[Feature] QuestionAnswerView UI 구현

### DIFF
--- a/Gom4ziz/Source/Domain/Model/MockData.swift
+++ b/Gom4ziz/Source/Domain/Model/MockData.swift
@@ -16,9 +16,9 @@ extension User {
 
 extension Artwork {
     static var mockData: Artwork {
-        Artwork(id: 1,
-                imageUrl: "",
-                question: "당신에게 있어서 방주란 무엇인가요?",
+        Artwork(id: 13,
+                imageUrl: "https://firebasestorage.googleapis.com/v0/b/gom4ziz.appspot.com/o/Rectangle393.png?alt=media&token=ae36097f-221b-4722-a145-068f1aaeca51",
+                question: "현대 사회에서 동물과 인류는 어떻게 공존과 공생을 할 수 있을까요?",
                 title: "작은 방주",
                 artist: "최우람")
     }

--- a/Gom4ziz/Source/Extension/NSLayoutConstraint.swift
+++ b/Gom4ziz/Source/Extension/NSLayoutConstraint.swift
@@ -1,0 +1,15 @@
+//
+//  NSLayoutConstraint.swift
+//  Gom4ziz
+//
+//  Created by JongHo Park on 2022/11/23.
+//
+
+import UIKit
+
+extension NSLayoutConstraint {
+    func withPriority(_ priority: Float) -> NSLayoutConstraint {
+        self.priority = UILayoutPriority(priority)
+        return self
+    }
+}

--- a/Gom4ziz/Source/Extension/UIImage+CIFilter.swift
+++ b/Gom4ziz/Source/Extension/UIImage+CIFilter.swift
@@ -1,0 +1,34 @@
+//
+//  UIImage.swift
+//  Gom4ziz
+//
+//  Created by JongHo Park on 2022/11/23.
+//
+
+import UIKit
+
+extension UIImage {
+    func setFilter(contrast: Double? = nil, exposure: Double? = nil) -> UIImage? {
+        guard contrast != nil || exposure != nil else {
+            return self
+        }
+        guard var inputImage = CIImage(image: self) else {
+            return nil
+        }
+        if let contrast {
+            inputImage = inputImage.applyingFilter("CIColorControls", parameters: [
+                kCIInputContrastKey: NSNumber(value: contrast)
+            ])
+        }
+        if let exposure {
+            inputImage = inputImage.applyingFilter("CIExposureAdjust", parameters: [
+                kCIInputEVKey: NSNumber(value: exposure)
+            ])
+        }
+        let context: CIContext = CIContext(options: nil)
+        guard let image = context.createCGImage(inputImage, from: inputImage.extent) else {
+            return nil
+        }
+        return UIImage(cgImage: image)
+    }
+}

--- a/Gom4ziz/Source/Extension/UIImage+CIFilter.swift
+++ b/Gom4ziz/Source/Extension/UIImage+CIFilter.swift
@@ -7,28 +7,48 @@
 
 import UIKit
 
+enum ImageFilterOption {
+    case contrast(Double)
+    case exposure(Double)
+}
+
 extension UIImage {
-    func setFilter(contrast: Double? = nil, exposure: Double? = nil) -> UIImage? {
-        guard contrast != nil || exposure != nil else {
-            return self
-        }
+
+    func setFilters(filterOptions: [ImageFilterOption]) -> UIImage? {
         guard var inputImage = CIImage(image: self) else {
             return nil
         }
-        if let contrast {
-            inputImage = inputImage.applyingFilter("CIColorControls", parameters: [
-                kCIInputContrastKey: NSNumber(value: contrast)
-            ])
+
+        // 이미지에 필터를 적용합니다.
+        for filterOption in filterOptions {
+            switch filterOption {
+            case .exposure(let value):
+                inputImage = inputImage.setExposure(value: value)
+            case .contrast(let value):
+                inputImage = inputImage.setContrast(value: value)
+            }
         }
-        if let exposure {
-            inputImage = inputImage.applyingFilter("CIExposureAdjust", parameters: [
-                kCIInputEVKey: NSNumber(value: exposure)
-            ])
-        }
+
         let context: CIContext = CIContext(options: nil)
         guard let image = context.createCGImage(inputImage, from: inputImage.extent) else {
             return nil
         }
+
+        // 필터가 적용된 이미지를 반환합니다.
         return UIImage(cgImage: image)
+    }
+}
+
+private extension CIImage {
+    func setContrast(value: Double) -> CIImage {
+        applyingFilter("CIColorControls", parameters: [
+            kCIInputContrastKey: NSNumber(value: value)
+        ])
+    }
+
+    func setExposure(value: Double) -> CIImage {
+        applyingFilter("CIExposureAdjust", parameters: [
+            kCIInputEVKey: NSNumber(value: value)
+        ])
     }
 }

--- a/Gom4ziz/Source/Extension/UIImageView.swift
+++ b/Gom4ziz/Source/Extension/UIImageView.swift
@@ -9,8 +9,11 @@ import UIKit
 
 extension UIImageView {
 
-    func loadImage(url: URL, option: NetworkImageCacheManager.Option = .useCache, completion: ((Error?) -> Void)? = nil) {
-        NetworkImageCacheManager.shared.loadImage(url: url, option: option) { image, error in
+    func loadImage(url: URL,
+                   option: NetworkImageManager.Option = .useCache,
+                   filterOptions: [ImageFilterOption] = [],
+                   completion: ((Error?) -> Void)? = nil) {
+        NetworkImageManager.shared.loadImage(url: url, option: option, filterOptions: filterOptions) { image, error in
             DispatchQueue.main.async {
                 guard error == nil, let image else {
                     completion?(error)
@@ -22,11 +25,15 @@ extension UIImageView {
         }
     }
 
-    func loadImage(url string: String, option: NetworkImageCacheManager.Option = .useCache, completion: ((Error?) -> Void)? = nil) {
+    func loadImage(url string: String,
+                   option: NetworkImageManager.Option = .useCache,
+                   filterOptions: [ImageFilterOption] = [],
+                   completion: ((Error?) -> Void)? = nil) {
         guard let url = URL(string: string) else {
+            completion?(URLError(URLError.badURL))
             return
         }
-        loadImage(url: url, option: option, completion: completion)
+        loadImage(url: url, option: option, filterOptions: filterOptions, completion: completion)
     }
 
 }

--- a/Gom4ziz/Source/Extension/UIImageView.swift
+++ b/Gom4ziz/Source/Extension/UIImageView.swift
@@ -10,7 +10,7 @@ import UIKit
 extension UIImageView {
 
     func loadImage(url: URL, option: NetworkImageCacheManager.Option = .useCache, completion: ((Error?) -> Void)? = nil) {
-        NetworkImageCacheManager.shared.loadImage(url: url) { image, error in
+        NetworkImageCacheManager.shared.loadImage(url: url, option: option) { image, error in
             DispatchQueue.main.async {
                 guard error == nil, let image else {
                     completion?(error)

--- a/Gom4ziz/Source/Presenter/Component/AsyncImageView.swift
+++ b/Gom4ziz/Source/Presenter/Component/AsyncImageView.swift
@@ -12,14 +12,20 @@ final class AsyncImageView: UIImageView {
     private let url: String
     private var errorIndicator: UIButton?
     private let progressView: UIView
+    private let exposure: Double?
+    private let contrast: Double?
 
     init(
         url string: String,
         progressView: UIView = UIActivityIndicatorView(style: .large),
-        contentMode: ContentMode = .scaleAspectFill
+        contentMode: ContentMode = .scaleAspectFill,
+        exposure: Double? = nil,
+        contrast: Double? = nil
     ) {
         self.url = string
+        self.exposure = exposure
         self.progressView = progressView
+        self.contrast = contrast
         super.init(frame: .zero)
         self.contentMode = contentMode
         self.isUserInteractionEnabled = true
@@ -67,6 +73,7 @@ private extension AsyncImageView {
         startLoading()
         loadImage(url: url) { [weak self] error in
             self?.progressView.removeFromSuperview()
+            self?.filterImage()
             guard error == nil else {
                 self?.addErrorIndicator(error!)
                 return
@@ -78,6 +85,13 @@ private extension AsyncImageView {
         addIndicator()
         errorIndicator?.removeFromSuperview()
         errorIndicator = nil
+    }
+
+    func filterImage() {
+        guard contrast != nil || exposure != nil else {
+            return
+        }
+        self.image = image?.setFilter(contrast: contrast, exposure: exposure)
     }
 }
 

--- a/Gom4ziz/Source/Presenter/Component/AsyncImageView.swift
+++ b/Gom4ziz/Source/Presenter/Component/AsyncImageView.swift
@@ -12,20 +12,17 @@ final class AsyncImageView: UIImageView {
     private let url: String
     private var errorIndicator: UIButton?
     private let progressView: UIView
-    private let exposure: Double?
-    private let contrast: Double?
+    private let filterOptions: [ImageFilterOption]
 
     init(
         url string: String,
         progressView: UIView = UIActivityIndicatorView(style: .large),
         contentMode: ContentMode = .scaleAspectFill,
-        exposure: Double? = nil,
-        contrast: Double? = nil
+        filterOptions: [ImageFilterOption] = []
     ) {
         self.url = string
-        self.exposure = exposure
+        self.filterOptions = filterOptions
         self.progressView = progressView
-        self.contrast = contrast
         super.init(frame: .zero)
         self.contentMode = contentMode
         self.isUserInteractionEnabled = true
@@ -71,9 +68,8 @@ private extension AsyncImageView {
 
     @objc func loadImageFromURL() {
         startLoading()
-        loadImage(url: url) { [weak self] error in
+        loadImage(url: url, filterOptions: filterOptions) { [weak self] error in
             self?.progressView.removeFromSuperview()
-            self?.filterImage()
             guard error == nil else {
                 self?.addErrorIndicator(error!)
                 return
@@ -85,13 +81,6 @@ private extension AsyncImageView {
         addIndicator()
         errorIndicator?.removeFromSuperview()
         errorIndicator = nil
-    }
-
-    func filterImage() {
-        guard contrast != nil || exposure != nil else {
-            return
-        }
-        self.image = image?.setFilter(contrast: contrast, exposure: exposure)
     }
 }
 

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerView.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerView.swift
@@ -14,12 +14,13 @@ final class QuestionAnswerView: BaseAutoLayoutUIView {
 
     private let divider: UIView = UIView()
     private let artwork: Artwork
-    private let questionLabel: UILabel = UILabel()
+    private let questionView: QuestionView
     private let disposeBag: DisposeBag = .init()
-    let answerInputTextView: PlaceholderTextView = .init(placeholder: "내용을 입력하세요.")
+    let answerInputTextView: PlaceholderTextView = .init(placeholder: "내용을 입력하세요")
 
     init(artwork: Artwork) {
         self.artwork = artwork
+        self.questionView = QuestionView(artwork: artwork)
         super.init(frame: .zero)
         self.backgroundColor = .white
     }
@@ -34,55 +35,42 @@ extension QuestionAnswerView {
 
     func addSubviews() {
         addSubview(divider)
-        addSubview(questionLabel)
+        addSubview(questionView)
         addSubview(answerInputTextView)
     }
 
     func setUpConstraints() {
-        questionLabel.translatesAutoresizingMaskIntoConstraints = false
+        questionView.translatesAutoresizingMaskIntoConstraints = false
+        questionView.setContentHuggingPriority(.defaultLow, for: .vertical)
         NSLayoutConstraint.activate([
-            questionLabel.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 12),
-            questionLabel.leftAnchor.constraint(equalTo: safeAreaLayoutGuide.leftAnchor, constant: 16),
-            questionLabel.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor, constant: -16),
-            questionLabel.heightAnchor.constraint(equalToConstant: 160)
+            questionView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 12),
+            questionView.leftAnchor.constraint(equalTo: safeAreaLayoutGuide.leftAnchor, constant: 16),
+            questionView.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor, constant: -16)
         ])
         divider.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            divider.leftAnchor.constraint(equalTo: questionLabel.leftAnchor),
-            divider.rightAnchor.constraint(equalTo: questionLabel.rightAnchor),
-            divider.topAnchor.constraint(equalTo: questionLabel.bottomAnchor, constant: 20),
+            divider.leftAnchor.constraint(equalTo: questionView.leftAnchor),
+            divider.rightAnchor.constraint(equalTo: questionView.rightAnchor),
+            divider.topAnchor.constraint(equalTo: questionView.bottomAnchor, constant: 20),
             divider.heightAnchor.constraint(equalToConstant: 2),
         ])
         answerInputTextView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            answerInputTextView.leftAnchor.constraint(equalTo: questionLabel.leftAnchor),
-            answerInputTextView.rightAnchor.constraint(equalTo: questionLabel.rightAnchor),
+            answerInputTextView.leftAnchor.constraint(equalTo: questionView.leftAnchor),
+            answerInputTextView.rightAnchor.constraint(equalTo: questionView.rightAnchor),
             answerInputTextView.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: 20),
-            answerInputTextView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 20)
+            answerInputTextView.bottomAnchor.constraint(equalTo: keyboardLayoutGuide.topAnchor, constant: -16)
         ])
     }
 
     func setUpUI() {
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTapGesture(sender:))))
-        setUpQuestionLabel()
         setUpDivider()
     }
 
 }
 
 private extension QuestionAnswerView {
-
-    func setUpQuestionLabel() {
-        questionLabel.textColor = .white
-        questionLabel.font = .systemFont(ofSize: 16, weight: .bold)
-        questionLabel.backgroundColor = .blackFont
-        questionLabel.numberOfLines = 0
-        questionLabel.lineBreakMode = .byWordWrapping
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineHeightMultiple = 1.26
-        paragraphStyle.alignment = .center
-        questionLabel.attributedText = NSMutableAttributedString(string: "# \(artwork.id)\n\(artwork.question)", attributes: [NSAttributedString.Key.paragraphStyle: paragraphStyle])
-    }
 
     func setUpDivider() {
         divider.backgroundColor = .black

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerView.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerView.swift
@@ -15,6 +15,7 @@ final class QuestionAnswerView: BaseAutoLayoutUIView {
     private let divider: UIView = UIView()
     private let artwork: Artwork
     private let questionView: QuestionView
+    private let myThinkLabel: UILabel = UILabel()
     private let disposeBag: DisposeBag = .init()
     let answerInputTextView: PlaceholderTextView = .init(placeholder: "내용을 입력하세요")
 
@@ -36,24 +37,33 @@ extension QuestionAnswerView {
     func addSubviews() {
         addSubview(divider)
         addSubview(questionView)
+        addSubview(myThinkLabel)
         addSubview(answerInputTextView)
     }
 
     func setUpConstraints() {
         questionView.translatesAutoresizingMaskIntoConstraints = false
-        questionView.setContentHuggingPriority(.defaultLow, for: .vertical)
+        questionView.setContentHuggingPriority(.defaultHigh, for: .vertical)
         NSLayoutConstraint.activate([
             questionView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 12),
             questionView.leftAnchor.constraint(equalTo: safeAreaLayoutGuide.leftAnchor, constant: 16),
             questionView.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor, constant: -16)
         ])
+
+        myThinkLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            myThinkLabel.leftAnchor.constraint(equalTo: questionView.leftAnchor),
+            myThinkLabel.topAnchor.constraint(equalTo: questionView.bottomAnchor, constant: 20)
+        ])
+
         divider.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             divider.leftAnchor.constraint(equalTo: questionView.leftAnchor),
             divider.rightAnchor.constraint(equalTo: questionView.rightAnchor),
-            divider.topAnchor.constraint(equalTo: questionView.bottomAnchor, constant: 20),
+            divider.topAnchor.constraint(equalTo: myThinkLabel.bottomAnchor, constant: 8),
             divider.heightAnchor.constraint(equalToConstant: 2),
         ])
+
         answerInputTextView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             answerInputTextView.leftAnchor.constraint(equalTo: questionView.leftAnchor),
@@ -66,6 +76,7 @@ extension QuestionAnswerView {
     func setUpUI() {
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTapGesture(sender:))))
         setUpDivider()
+        setUpMyThinkLabel()
     }
 
 }
@@ -74,6 +85,11 @@ private extension QuestionAnswerView {
 
     func setUpDivider() {
         divider.backgroundColor = .black
+    }
+
+    func setUpMyThinkLabel() {
+        myThinkLabel.text = "나의 생각"
+        myThinkLabel.font = .systemFont(ofSize: 15, weight: .black)
     }
 
     /// 유저가 화면을 탭할 경우, 키보드를 숨깁니다.

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerViewController.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerViewController.swift
@@ -13,17 +13,14 @@ import RxSwift
 final class QuestionAnswerViewController: UIViewController {
 
     private let questionAnswerView: QuestionAnswerView
-    private lazy var nextButton: UIBarButtonItem = {
-        let button: UIBarButtonItem = UIBarButtonItem(title: "다음", style: .plain, target: self, action: #selector(onNextButtonClick(sender: )))
-        button.tintColor = .black
-        return button
-    }()
+    private let nextButton: UIBarButtonItem
     private let viewModel: QuestionAnswerViewModel
     private let disposeBag: DisposeBag = .init()
 
     init(artwork: Artwork) {
         self.questionAnswerView = QuestionAnswerView(artwork: artwork)
         self.viewModel = QuestionAnswerViewModel(of: artwork)
+        self.nextButton = UIBarButtonItem(title: "다음")
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -59,7 +56,8 @@ private extension QuestionAnswerViewController {
 
     func focusOnTextView() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [self] in
-            _ = questionAnswerView.answerInputTextView
+            _ = questionAnswerView
+                .answerInputTextView
                 .becomeFirstResponder()
         }
     }
@@ -79,6 +77,7 @@ private extension QuestionAnswerViewController {
             })
             .disposed(by: disposeBag)
     }
+
 }
 
 // MARK: - Navigation Bar 설정 부분
@@ -88,11 +87,18 @@ private extension QuestionAnswerViewController {
         let numberOfArtwork: Int = viewModel.artwork.id
         navigationItem.title = "\(numberOfArtwork)번째 티라미수"
         navigationItem.rightBarButtonItem = nextButton
+        setUpNextButton()
     }
 
-    @objc func onNextButtonClick(sender: UIBarButtonItem) {
-        viewModel.myAnswer = questionAnswerView.answerInputTextView.text
-        navigationController?.pushViewController(QuestionAnswerViewController(artwork: .mockData), animated: true)
+    func setUpNextButton() {
+        nextButton.tintColor = .black
+        nextButton
+            .rx
+            .tap
+            .bind { _ in
+
+            }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerViewController.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerViewController.swift
@@ -12,15 +12,24 @@ import RxSwift
 
 final class QuestionAnswerViewController: UIViewController {
 
-    private let questionAnswerView: QuestionAnswerView = QuestionAnswerView(artwork: Artwork.mockData)
-
+    private let questionAnswerView: QuestionAnswerView
     private lazy var nextButton: UIBarButtonItem = {
         let button: UIBarButtonItem = UIBarButtonItem(title: "다음", style: .plain, target: self, action: #selector(onNextButtonClick(sender: )))
         button.tintColor = .black
         return button
     }()
-
+    private let viewModel: QuestionAnswerViewModel
     private let disposeBag: DisposeBag = .init()
+
+    init(artwork: Artwork) {
+        self.questionAnswerView = QuestionAnswerView(artwork: artwork)
+        self.viewModel = QuestionAnswerViewModel(of: artwork)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
 
     override func viewDidLoad() {
         setUpNavigationBar()
@@ -49,8 +58,10 @@ private extension QuestionAnswerViewController {
     }
 
     func focusOnTextView() {
-        _ = questionAnswerView.answerInputTextView
-            .becomeFirstResponder()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [self] in
+            _ = questionAnswerView.answerInputTextView
+                .becomeFirstResponder()
+        }
     }
 
     func setUpObservers() {
@@ -74,12 +85,14 @@ private extension QuestionAnswerViewController {
 private extension QuestionAnswerViewController {
 
     func setUpNavigationBar() {
-        navigationItem.title = "작가의 질문"
+        let numberOfArtwork: Int = viewModel.artwork.id
+        navigationItem.title = "\(numberOfArtwork)번째 티라미수"
         navigationItem.rightBarButtonItem = nextButton
     }
 
     @objc func onNextButtonClick(sender: UIBarButtonItem) {
-
+        viewModel.myAnswer = questionAnswerView.answerInputTextView.text
+        navigationController?.pushViewController(QuestionAnswerViewController(artwork: .mockData), animated: true)
     }
 }
 
@@ -87,7 +100,7 @@ private extension QuestionAnswerViewController {
 import SwiftUI
 struct QuestionAnswerViewControllerPreview: PreviewProvider {
     static var previews: some View {
-        UINavigationController(rootViewController: QuestionAnswerViewController())
+        UINavigationController(rootViewController: QuestionAnswerViewController(artwork: Artwork.mockData))
             .toPreview()
     }
 }

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerViewModel.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerViewModel.swift
@@ -1,0 +1,20 @@
+//
+//  QuestionAnswerViewModel.swift
+//  Gom4ziz
+//
+//  Created by JongHo Park on 2022/11/23.
+//
+
+import RxSwift
+import RxRelay
+
+final class QuestionAnswerViewModel {
+    let artwork: Artwork
+    var myAnswer: String
+
+    init(of artwork: Artwork) {
+        self.artwork = artwork
+        self.myAnswer = ""
+    }
+
+}

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionView.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionView.swift
@@ -21,8 +21,10 @@ final class QuestionView: BaseAutoLayoutUIView {
         questionImageView = AsyncImageView(
             url: artwork.imageUrl,
             contentMode: .scaleAspectFill,
-            exposure: 0.3,
-            contrast: 0.95)
+            filterOptions: [
+                .contrast(1.2),
+                .exposure(0.3)
+            ])
         super.init(frame: .zero)
     }
 

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionView.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionView.swift
@@ -30,6 +30,10 @@ final class QuestionView: BaseAutoLayoutUIView {
         fatalError()
     }
 
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: 100, height: 200)
+    }
+
 }
 
 extension QuestionView {
@@ -37,7 +41,9 @@ extension QuestionView {
     func addSubviews() {
         addSubview(questionImageView)
         addSubview(infoContainer)
-        infoContainer.addSubviews(questionNumberLabel, questionLabel, whiteDivider)
+        infoContainer.addSubview(questionNumberLabel)
+        infoContainer.addSubview(questionLabel)
+        infoContainer.addSubview(whiteDivider)
     }
 
     func setUpConstraints() {
@@ -73,6 +79,8 @@ private extension QuestionView {
 
     func setUpQuestionNumberLabelConstraints() {
         questionNumberLabel.translatesAutoresizingMaskIntoConstraints = false
+        questionNumberLabel.setContentHuggingPriority(.required, for: .vertical)
+        questionNumberLabel.setContentCompressionResistancePriority(.required, for: .vertical)
         NSLayoutConstraint.activate([
             questionNumberLabel.centerXAnchor.constraint(equalTo: infoContainer.centerXAnchor),
             questionNumberLabel.bottomAnchor.constraint(equalTo: whiteDivider.topAnchor, constant: -5),
@@ -82,6 +90,8 @@ private extension QuestionView {
     }
     func setUpQuestionLabelConstraints() {
         questionLabel.translatesAutoresizingMaskIntoConstraints = false
+        questionLabel.setContentHuggingPriority(.required, for: .vertical)
+        questionLabel.setContentCompressionResistancePriority(.required, for: .vertical)
         NSLayoutConstraint.activate([
             questionLabel.leftAnchor.constraint(equalTo: infoContainer.leftAnchor, constant: 16),
             questionLabel.rightAnchor.constraint(equalTo: infoContainer.rightAnchor, constant: -16),
@@ -90,7 +100,6 @@ private extension QuestionView {
     }
     func setUpQuestionImageViewConstraints() {
         questionImageView.translatesAutoresizingMaskIntoConstraints = false
-        questionImageView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         NSLayoutConstraint.activate([
             questionImageView.topAnchor.constraint(equalTo: infoContainer.topAnchor),
             questionImageView.bottomAnchor.constraint(equalTo: infoContainer.bottomAnchor),
@@ -133,7 +142,7 @@ private extension QuestionView {
     }
 
     func setUpQuestionImageView() {
-        
+        questionImageView.transform = CGAffineTransform(scaleX: 1.5, y: 1.5)
     }
 
     func setUpWhiteDivider() {

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionView.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionView.swift
@@ -1,0 +1,142 @@
+//
+//  QuestionView.swift
+//  Gom4ziz
+//
+//  Created by JongHo Park on 2022/11/23.
+//
+
+import UIKit
+
+final class QuestionView: BaseAutoLayoutUIView {
+
+    private let artwork: Artwork
+    private let questionNumberLabel: UILabel = UILabel()
+    private let questionImageView: AsyncImageView
+    private let questionLabel: UILabel = UILabel()
+    private let whiteDivider: UIView = UIView()
+    private let infoContainer: UIView = UIView()
+
+    init(artwork: Artwork) {
+        self.artwork = artwork
+        questionImageView = AsyncImageView(
+            url: artwork.imageUrl,
+            contentMode: .scaleAspectFill,
+            exposure: 0.3,
+            contrast: 0.95)
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+}
+
+extension QuestionView {
+
+    func addSubviews() {
+        addSubview(questionImageView)
+        addSubview(infoContainer)
+        infoContainer.addSubviews(questionNumberLabel, questionLabel, whiteDivider)
+    }
+
+    func setUpConstraints() {
+        setUpInfoContainerConstaints()
+        setUpQuestionLabelConstraints()
+        setUpWhiteDividerConstraints()
+        setUpQuestionNumberLabelConstraints()
+        setUpQuestionImageViewConstraints()
+    }
+
+    func setUpUI() {
+        setUpQuestionImageView()
+        setUpQuestionLabel()
+        setUpWhiteDivider()
+        setUpQuestionNumberLabel()
+        setUpSelf()
+    }
+
+}
+
+// MARK: - 오토레이아웃 제약조건 설정
+private extension QuestionView {
+
+    func setUpInfoContainerConstaints() {
+        infoContainer.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            infoContainer.topAnchor.constraint(equalTo: topAnchor),
+            infoContainer.leftAnchor.constraint(equalTo: leftAnchor),
+            infoContainer.rightAnchor.constraint(equalTo: rightAnchor),
+            infoContainer.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+    func setUpQuestionNumberLabelConstraints() {
+        questionNumberLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            questionNumberLabel.centerXAnchor.constraint(equalTo: infoContainer.centerXAnchor),
+            questionNumberLabel.bottomAnchor.constraint(equalTo: whiteDivider.topAnchor, constant: -5),
+            questionNumberLabel.topAnchor.constraint(equalTo: infoContainer.topAnchor, constant: 48)
+        ])
+
+    }
+    func setUpQuestionLabelConstraints() {
+        questionLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            questionLabel.leftAnchor.constraint(equalTo: infoContainer.leftAnchor, constant: 16),
+            questionLabel.rightAnchor.constraint(equalTo: infoContainer.rightAnchor, constant: -16),
+            questionLabel.bottomAnchor.constraint(equalTo: infoContainer.bottomAnchor, constant: -48)
+        ])
+    }
+    func setUpQuestionImageViewConstraints() {
+        questionImageView.translatesAutoresizingMaskIntoConstraints = false
+        questionImageView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        NSLayoutConstraint.activate([
+            questionImageView.topAnchor.constraint(equalTo: infoContainer.topAnchor),
+            questionImageView.bottomAnchor.constraint(equalTo: infoContainer.bottomAnchor),
+            questionImageView.leftAnchor.constraint(equalTo: infoContainer.leftAnchor),
+            questionImageView.rightAnchor.constraint(equalTo: infoContainer.rightAnchor),
+        ])
+    }
+    func setUpWhiteDividerConstraints() {
+        whiteDivider.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            whiteDivider.bottomAnchor.constraint(equalTo: questionLabel.topAnchor, constant: -9),
+            whiteDivider.widthAnchor.constraint(equalToConstant: 40),
+            whiteDivider.centerXAnchor.constraint(equalTo: infoContainer.centerXAnchor),
+            whiteDivider.heightAnchor.constraint(equalToConstant: 2)
+        ])
+    }
+}
+
+// MARK: - UI 설정
+private extension QuestionView {
+
+    func setUpSelf() {
+        layer.cornerRadius = 12
+        layer.masksToBounds = true
+    }
+
+    func setUpQuestionNumberLabel() {
+        questionNumberLabel.text = "\(artwork.id)번째 티라미술"
+        questionNumberLabel.font = .systemFont(ofSize: 14, weight: .bold)
+        questionNumberLabel.textColor = .white
+    }
+
+    func setUpQuestionLabel() {
+        questionLabel.textAlignment = .center
+        questionLabel.text = "\(artwork.question)"
+        questionLabel.textColor = .white
+        questionLabel.numberOfLines = 0
+        questionLabel.lineBreakMode = .byWordWrapping
+        questionLabel.font = .systemFont(ofSize: 22, weight: .bold)
+    }
+
+    func setUpQuestionImageView() {
+        
+    }
+
+    func setUpWhiteDivider() {
+        whiteDivider.backgroundColor = .white
+    }
+}


### PR DESCRIPTION
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.
🔒 Close #49 

## 작업 내용 (Content)
- Question에 답할 수 있는 UI를 구현했습니다.
- 또한 AsyncImage를 리팩토링했습니다.  

## Review points
- Image에 적용할 수 있는 필터를 ImageFilterOption enum으로 나타냈으며, 개발자가 AsyncImageView를 생성할 때, 이미지에 어떤 필터를 적용할 것인지 배열로 전달할 수 있습니다.
- [ImageFilterOption](https://github.com/DeveloperAcademy-POSTECH/MacC_Team_Beartear/compare/develop...DeveloperAcademy-POSTECH:Feat%2F%2349_qustion_answer_ui?expand=1&title=49%20%5BFeature%5D%20질문에%20대한%20답변을%20할%20수%20있다.#diff-601ba98f04dbe4b0a6ff3967ee2d134709edf550f8295c529e16c720d3bfcb78R10-R13) 

- [UIView의 intrinsic Size를 결정하기 위해서, UIView subViews 들의 제약조건을 활용했습니다. 이 때, UIView사이즈를 설정하기 위해서는 UILabel의 intrinsicSize를 유지해야 하기 때문에, contentHuggingPriority와, compressionPriority 를 최상으로 설정했습니다.](https://github.com/DeveloperAcademy-POSTECH/MacC_Team_Beartear/compare/develop...DeveloperAcademy-POSTECH:Feat%2F%2349_qustion_answer_ui?expand=1&title=49%20%5BFeature%5D%20질문에%20대한%20답변을%20할%20수%20있다.#diff-3682a9f762c91d8a2ebbb239d7b3b126d1f0a7615c2eb1fc1e774497dba75c97R83-R85)

<img width="982" alt="image" src="https://user-images.githubusercontent.com/57793298/203678367-11e40dbe-f10c-4c7e-aa0f-9bb253810606.png">


## 기타 사항 (Etc)
- 없음

## 관련 사진 gif 및 (Optional)
<img src = "https://user-images.githubusercontent.com/57793298/203676921-2225215f-b060-4550-a84e-4013835cf217.png" width = 300>

## References (Optional)
- https://www.hackingwithswift.com/example-code/media/how-to-filter-images-using-core-image-and-cifilter (이미지 필터)