### PR TITLE
[Feature] #90: ArtworkDescription과 ArtworkReview를 불러와 유저에게 보여준다.

### DIFF
--- a/Gom4ziz/Resource/Assets.xcassets/Gray1.colorset/Contents.json
+++ b/Gom4ziz/Resource/Assets.xcassets/Gray1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEF",
+          "green" : "0xEF",
+          "red" : "0xEF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Gom4ziz/Resource/Assets.xcassets/Gray3.colorset/Contents.json
+++ b/Gom4ziz/Resource/Assets.xcassets/Gray3.colorset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x74",
+          "green" : "0x74",
+          "red" : "0x74"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/Gom4ziz/Source/Constants/Typography.swift
+++ b/Gom4ziz/Source/Constants/Typography.swift
@@ -8,29 +8,35 @@
 import UIKit
 
 enum Typohgraphy {
-    case title
-    case sectionHeader
-    case navigationHeader
-    case primary
-    case secondary
-    case description
+    case Display1
+    case Display2
+    case Display3
+    case Title
+    case Headline1
+    case Headline2
+    case SubHeadline
+    case Body1
+    case Body2
+    case Caption
+    case NavigationTitle
+    case NavigationButton
 }
 
 extension Typohgraphy {
-    var toValue: (CGFloat, UIFont.Weight) {
+    var toValue: (CGFloat, CGFloat, UIFont.Weight) {
         switch self {
-        case .title:
-            return (1.5, .bold)
-        case .sectionHeader:
-            return (1.5, .heavy)
-        case .navigationHeader:
-            return (1.5, .semibold)
-        case .primary:
-            return (1.8, .light)
-        case .secondary:
-            return (1.5, .light)
-        case .description:
-            return (1.5, .regular)
+        case .Display1: return (28, 1.5, .bold)
+        case .Display2: return (24, 1.5, .bold)
+        case .Display3: return (22, 1.5, .bold)
+        case .Title: return (20, 1.2, .bold)
+        case .Headline1: return (17, 1.4, .bold)
+        case .Headline2: return (16, 1.2, .heavy)
+        case .SubHeadline: return (16, 1.2, .medium)
+        case .Body1: return (18, 1.8, .light)
+        case .Body2: return (14, 1.5, .light)
+        case .Caption: return (14, 1.5, .bold)
+        case .NavigationTitle: return (16, 1.5, .semibold)
+        case .NavigationButton: return (16, 1.5, .regular)
         }
     }
 }

--- a/Gom4ziz/Source/Constants/Typography.swift
+++ b/Gom4ziz/Source/Constants/Typography.swift
@@ -1,0 +1,36 @@
+//
+//  Typography.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/11/23.
+//
+
+import UIKit
+
+enum Typohgraphy {
+    case title
+    case sectionHeader
+    case navigationHeader
+    case primary
+    case secondary
+    case description
+}
+
+extension Typohgraphy {
+    var toValue: (CGFloat, UIFont.Weight) {
+        switch self {
+        case .title:
+            return (1.5, .bold)
+        case .sectionHeader:
+            return (1.5, .heavy)
+        case .navigationHeader:
+            return (1.5, .semibold)
+        case .primary:
+            return (1.8, .light)
+        case .secondary:
+            return (1.5, .light)
+        case .description:
+            return (1.5, .regular)
+        }
+    }
+}

--- a/Gom4ziz/Source/Extension/UILabel+TextStyle.swift
+++ b/Gom4ziz/Source/Extension/UILabel+TextStyle.swift
@@ -1,0 +1,73 @@
+//
+//  LineHeight.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/11/23.
+//
+
+import UIKit
+
+enum TextStyle {
+    case textStyle(size: CGFloat, type: Typohgraphy)
+}
+
+extension UILabel {
+    func textStyle(_ style: TextStyle, _ color: UIColor) {
+        if case .textStyle(let size, let type) = style {
+            let (lineheight, fontWeight) = type.toValue
+            self.setLineSpacing(lineSpacing: lineheight)
+            
+            switch size {
+            case 14:
+                self.font = .systemFont(ofSize: 14, weight: fontWeight)
+                self.textColor = color
+            case 15:
+                self.font = .systemFont(ofSize: 15, weight: fontWeight)
+                self.textColor = color
+            case 16:
+                self.font = .systemFont(ofSize: 16, weight: fontWeight)
+                self.textColor = color
+            case 17:
+                self.font = .systemFont(ofSize: 17, weight: fontWeight)
+                self.textColor = color
+            case 18:
+                self.font = .systemFont(ofSize: 18, weight: fontWeight)
+                self.textColor = color
+            case 20:
+                self.font = .systemFont(ofSize: 20, weight: fontWeight)
+                self.textColor = color
+            case 24:
+                self.font = .systemFont(ofSize: 24, weight: fontWeight)
+                self.textColor = color
+            default:
+                break
+            }
+        }
+    }
+    
+    func setLineSpacing(kernValue: Double = 0.0,
+                          lineSpacing: CGFloat = 0.0,
+                          lineHeightMultiple: CGFloat = 0.0) {
+          guard let labelText = self.text else { return }
+          
+          let paragraphStyle = NSMutableParagraphStyle()
+          paragraphStyle.lineSpacing = lineSpacing
+          paragraphStyle.lineHeightMultiple = lineHeightMultiple
+          
+          let attributedString: NSMutableAttributedString
+          if let labelAttributedText = self.attributedText {
+              attributedString = NSMutableAttributedString(attributedString: labelAttributedText)
+          } else {
+              attributedString = NSMutableAttributedString(string: labelText)
+          }
+          
+          attributedString.addAttribute(NSAttributedString.Key.paragraphStyle,
+                                        value: paragraphStyle,
+                                        range: NSMakeRange(0, attributedString.length))
+          attributedString.addAttribute(NSAttributedString.Key.kern,
+                                        value: kernValue,
+                                        range: NSMakeRange(0, attributedString.length))
+          
+          self.attributedText = attributedString
+      }
+}

--- a/Gom4ziz/Source/Extension/UILabel+TextStyle.swift
+++ b/Gom4ziz/Source/Extension/UILabel+TextStyle.swift
@@ -12,37 +12,11 @@ enum TextStyle {
 }
 
 extension UILabel {
-    func textStyle(_ style: TextStyle, _ color: UIColor) {
-        if case .textStyle(let size, let type) = style {
-            let (lineheight, fontWeight) = type.toValue
-            self.setLineSpacing(lineSpacing: lineheight)
-            
-            switch size {
-            case 14:
-                self.font = .systemFont(ofSize: 14, weight: fontWeight)
-                self.textColor = color
-            case 15:
-                self.font = .systemFont(ofSize: 15, weight: fontWeight)
-                self.textColor = color
-            case 16:
-                self.font = .systemFont(ofSize: 16, weight: fontWeight)
-                self.textColor = color
-            case 17:
-                self.font = .systemFont(ofSize: 17, weight: fontWeight)
-                self.textColor = color
-            case 18:
-                self.font = .systemFont(ofSize: 18, weight: fontWeight)
-                self.textColor = color
-            case 20:
-                self.font = .systemFont(ofSize: 20, weight: fontWeight)
-                self.textColor = color
-            case 24:
-                self.font = .systemFont(ofSize: 24, weight: fontWeight)
-                self.textColor = color
-            default:
-                break
-            }
-        }
+    func textStyle(_ typography: Typohgraphy, _ color: UIColor) {
+        let (fontSize, lineheight, fontWeight) = typography.toValue
+        self.font = .systemFont(ofSize: fontSize, weight: fontWeight)
+        self.setLineSpacing(lineSpacing: lineheight)
+        self.textColor = color
     }
     
     func setLineSpacing(kernValue: Double = 0.0,

--- a/Gom4ziz/Source/Extension/UILabel+TextStyle.swift
+++ b/Gom4ziz/Source/Extension/UILabel+TextStyle.swift
@@ -7,10 +7,6 @@
 
 import UIKit
 
-enum TextStyle {
-    case textStyle(size: CGFloat, type: Typohgraphy)
-}
-
 extension UILabel {
     func textStyle(_ typography: Typohgraphy, _ color: UIColor) {
         let (fontSize, lineheight, fontWeight) = typography.toValue

--- a/Gom4ziz/Source/Extension/UITextView+TextStyle.swift
+++ b/Gom4ziz/Source/Extension/UITextView+TextStyle.swift
@@ -1,0 +1,31 @@
+//
+//  UITextView+TextStyle.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/11/25.
+//
+
+import UIKit
+
+extension UITextView {
+    
+    func textStyle(_ typography: Typohgraphy, _ color: UIColor) {
+        let (fontSize, lineheight, fontWeight) = typography.toValue
+        self.font = .systemFont(ofSize: fontSize, weight: fontWeight)
+        self.setTypingAttributes(lineSpacing: lineheight)
+        self.textColor = color
+    }
+    
+    func setTypingAttributes(kernValue: Double = 0.0,
+                        lineSpacing: CGFloat = 0.0,
+                        lineHeightMultiple: CGFloat = 0.0) {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = lineSpacing
+        paragraphStyle.lineHeightMultiple = lineHeightMultiple
+        
+        let attributes: [NSAttributedString.Key: Any] = [.kern: -0.6,
+                                                         .paragraphStyle: paragraphStyle]
+        self.typingAttributes = attributes
+    }
+    
+}

--- a/Gom4ziz/Source/Presenter/Component/SectionTitleView.swift
+++ b/Gom4ziz/Source/Presenter/Component/SectionTitleView.swift
@@ -14,7 +14,7 @@ final class SectionTitleView: UIView {
     private lazy var sectionTitleLabel: UILabel = {
         let label = UILabel()
         label.text = title
-        label.textStyle(.textStyle(size: 15, type: .sectionHeader), .blackFont)
+        label.textStyle(.Headline2, .blackFont)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()

--- a/Gom4ziz/Source/Presenter/Component/SectionTitleView.swift
+++ b/Gom4ziz/Source/Presenter/Component/SectionTitleView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class SectionTitleView: UIView {
+final class SectionTitleView: BaseAutoLayoutUIView {
     
     let title: String
     
@@ -40,10 +40,6 @@ final class SectionTitleView: UIView {
     init(title: String) {
         self.title = title
         super.init(frame: .zero)
-        
-        addSubviews()
-        setUpConstraints()
-        setUpUI()
     }
     
     required init?(coder: NSCoder) {
@@ -52,7 +48,8 @@ final class SectionTitleView: UIView {
     
 }
 
-private extension SectionTitleView {
+extension SectionTitleView {
+    
     func addSubviews() {
         self.addSubview(sectionTitleStackView)
     }
@@ -76,4 +73,5 @@ private extension SectionTitleView {
     func setUpUI() {
         self.backgroundColor = .white
     }
+    
 }

--- a/Gom4ziz/Source/Presenter/Component/SectionTitleView.swift
+++ b/Gom4ziz/Source/Presenter/Component/SectionTitleView.swift
@@ -1,0 +1,79 @@
+//
+//  SectionTitleView.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/11/23.
+//
+
+import UIKit
+
+final class SectionTitleView: UIView {
+    
+    let title: String
+    
+    private lazy var sectionTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = title
+        label.textStyle(.textStyle(size: 15, type: .sectionHeader), .blackFont)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let sectionTitleDividerView: UIView = {
+        let divider = UIView()
+        divider.backgroundColor = .blackFont
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        return divider
+    }()
+    
+    private lazy var sectionTitleStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [sectionTitleLabel,
+                                                       sectionTitleDividerView])
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = .fill
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    init(title: String) {
+        self.title = title
+        super.init(frame: .zero)
+        
+        addSubviews()
+        setUpConstraints()
+        setUpUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension SectionTitleView {
+    func addSubviews() {
+        self.addSubview(sectionTitleStackView)
+    }
+    
+    func setUpConstraints() {
+        NSLayoutConstraint.activate([
+            sectionTitleStackView.topAnchor.constraint(equalTo: self.topAnchor),
+            sectionTitleStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            sectionTitleStackView.leftAnchor.constraint(equalTo: self.leftAnchor),
+            sectionTitleStackView.rightAnchor.constraint(equalTo: self.rightAnchor),
+            
+            sectionTitleLabel.topAnchor.constraint(equalTo: sectionTitleStackView.topAnchor),
+            
+            sectionTitleDividerView.leftAnchor.constraint(equalTo: sectionTitleLabel.leftAnchor),
+            sectionTitleDividerView.rightAnchor.constraint(equalTo: sectionTitleLabel.rightAnchor),
+            sectionTitleDividerView.bottomAnchor.constraint(equalTo: sectionTitleStackView.bottomAnchor),
+            sectionTitleDividerView.heightAnchor.constraint(equalToConstant: 2)
+        ])
+    }
+    
+    func setUpUI() {
+        self.backgroundColor = .white
+    }
+}

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedView.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedView.swift
@@ -1,0 +1,247 @@
+//
+//  MyFeedView.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/11/23.
+//
+
+import UIKit
+
+final class MyFeedView: BaseAutoLayoutUIView {
+    
+    private let artwork: Artwork
+    private let artworkDescription: ArtworkDescription
+    private let artworkReview: ArtworkReview
+    private let highlights: [Highlight]
+    
+    // MARK: - UI Component
+    
+    private lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+    
+    // N번째 티라미술
+    private lazy var feedSectionTitleView: SectionTitleView = .init(title: "\(artwork.id)번째 티라미술")
+    
+    private lazy var questionLabel: UILabel = {
+        let label = UILabel()
+        label.text = artwork.question
+        label.numberOfLines = 0
+        label.textStyle(.textStyle(size: 24, type: .title), .blackFont)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var questionAnswerLabel: UILabel = {
+        let label = UILabel()
+        label.text = artworkReview.questionAnswer
+        label.numberOfLines = 0
+        label.textStyle(.textStyle(size: 17, type: .secondary), .blackFont)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var questionStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [questionLabel,
+                                                      questionAnswerLabel])
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = .fill
+        stackView.spacing = 20
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    private lazy var feedStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [feedSectionTitleView,
+                                                      questionStackView])
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = .fill
+        stackView.spacing = 20
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    // 작품 정보
+    
+    private lazy var artworkImageView: UIImageView = {
+        let imageView = UIImageView()
+        // TODO: 이미지 불러오기
+//        imageView.image = UIImage(named: artwork.imageUrl)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    private lazy var artworkTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = artwork.title
+        label.numberOfLines = 0
+        label.textStyle(.textStyle(size: 20, type: .title), .blackFont)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var artworkArtistLabel: UILabel = {
+        let label = UILabel()
+        label.text = artwork.artist
+        label.numberOfLines = 0
+        label.textStyle(.textStyle(size: 15, type: .description), .gray3)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var artworkInfoStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [artworkTitleLabel,
+                                                      artworkArtistLabel])
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = .center
+        stackView.spacing = 4
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    private lazy var artworkStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [artworkImageView,
+                                                       artworkInfoStackView])
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = .center
+        stackView.spacing = 20
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    // 작품 소개
+    
+    private lazy var artworkDesciptionSectionTitleView: SectionTitleView = .init(title: "작품 소개")
+    
+    private lazy var artworkDescriptionLabel: UILabel = {
+        let label = UILabel()
+        label.text = artworkDescription.content
+        label.numberOfLines = 0
+        label.textStyle(.textStyle(size: 18, type: .primary), .blackFont)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var artworkDescriptionStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [artworkDesciptionSectionTitleView,
+                                                       artworkDescriptionLabel])
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = .fill
+        stackView.spacing = 20
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    // 나의 감상
+    
+    private lazy var reviewSectionTitleView: SectionTitleView = .init(title: "나의 감상")
+    
+    private lazy var reviewLabel: UILabel = {
+        let label = UILabel()
+        label.text = artworkReview.review
+        label.numberOfLines = 0
+        label.textStyle(.textStyle(size: 18, type: .primary), .blackFont)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var reviewStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [reviewSectionTitleView,
+                                                       reviewLabel])
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = .fill
+        stackView.spacing = 20
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    private lazy var myFeedStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [feedStackView,
+                                                       artworkStackView,
+                                                       artworkDescriptionStackView,
+                                                       reviewStackView])
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = .fill
+        stackView.spacing = 40
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    init(artwork: Artwork,
+         artworkDescription: ArtworkDescription,
+         artworkReview: ArtworkReview,
+         highlights: [Highlight]) {
+        self.artwork = artwork
+        self.artworkDescription = artworkDescription
+        self.artworkReview = artworkReview
+        self.highlights = highlights
+        super.init(frame: .zero)
+        self.backgroundColor = .white
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+extension MyFeedView {
+    
+    func addSubviews() {
+        self.addSubview(scrollView)
+        scrollView.addSubview(myFeedStackView)
+    }
+    
+    func setUpConstraints() {
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            scrollView.leftAnchor.constraint(equalTo: leftAnchor),
+            scrollView.rightAnchor.constraint(equalTo: rightAnchor),
+            
+            myFeedStackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            myFeedStackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            myFeedStackView.leftAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leftAnchor),
+            myFeedStackView.rightAnchor.constraint(equalTo: scrollView.contentLayoutGuide.rightAnchor),
+            myFeedStackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+
+            feedStackView.topAnchor.constraint(equalTo: myFeedStackView.topAnchor, constant: 12),
+            feedStackView.leftAnchor.constraint(equalTo: myFeedStackView.leftAnchor, constant: 16),
+            feedStackView.rightAnchor.constraint(equalTo: myFeedStackView.rightAnchor, constant: -16),
+            
+            artworkStackView.leftAnchor.constraint(equalTo: myFeedStackView.leftAnchor),
+            artworkStackView.rightAnchor.constraint(equalTo: myFeedStackView.rightAnchor),
+            artworkImageView.widthAnchor.constraint(equalTo: myFeedStackView.widthAnchor),
+           
+            artworkDescriptionStackView.leftAnchor.constraint(equalTo: myFeedStackView.leftAnchor, constant: 16),
+            artworkDescriptionStackView.rightAnchor.constraint(equalTo: myFeedStackView.rightAnchor, constant: -16),
+            
+            reviewStackView.leftAnchor.constraint(equalTo: myFeedStackView.leftAnchor, constant: 16),
+            reviewStackView.rightAnchor.constraint(equalTo: myFeedStackView.rightAnchor, constant: -16),
+            reviewStackView.bottomAnchor.constraint(equalTo: myFeedStackView.bottomAnchor)
+        ])
+    }
+    
+    func setUpUI() {
+        
+    }
+    
+}
+
+#if DEBUG
+import SwiftUI
+struct MyFeedViewPreview: PreviewProvider {
+    static var previews: some View {
+        MyFeedView(artwork: .mockData, artworkDescription: .mockData, artworkReview: .mockData, highlights: []).toPreview()
+    }
+}
+#endif

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedView.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedView.swift
@@ -29,7 +29,7 @@ final class MyFeedView: BaseAutoLayoutUIView {
         let label = UILabel()
         label.text = artwork.question
         label.numberOfLines = 0
-        label.textStyle(.textStyle(size: 24, type: .title), .blackFont)
+        label.textStyle(.Display2, .blackFont)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -38,7 +38,7 @@ final class MyFeedView: BaseAutoLayoutUIView {
         let label = UILabel()
         label.text = artworkReview.questionAnswer
         label.numberOfLines = 0
-        label.textStyle(.textStyle(size: 17, type: .secondary), .blackFont)
+        label.textStyle(.Body1, .blackFont)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -79,7 +79,7 @@ final class MyFeedView: BaseAutoLayoutUIView {
         let label = UILabel()
         label.text = artwork.title
         label.numberOfLines = 0
-        label.textStyle(.textStyle(size: 20, type: .title), .blackFont)
+        label.textStyle(.Title, .blackFont)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -88,7 +88,7 @@ final class MyFeedView: BaseAutoLayoutUIView {
         let label = UILabel()
         label.text = artwork.artist
         label.numberOfLines = 0
-        label.textStyle(.textStyle(size: 15, type: .description), .gray3)
+        label.textStyle(.Body2, .gray3)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -123,7 +123,7 @@ final class MyFeedView: BaseAutoLayoutUIView {
         let label = UILabel()
         label.text = artworkDescription.content
         label.numberOfLines = 0
-        label.textStyle(.textStyle(size: 18, type: .primary), .blackFont)
+        label.textStyle(.Body1, .blackFont)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -147,7 +147,7 @@ final class MyFeedView: BaseAutoLayoutUIView {
         let label = UILabel()
         label.text = artworkReview.review
         label.numberOfLines = 0
-        label.textStyle(.textStyle(size: 18, type: .primary), .blackFont)
+        label.textStyle(.Body1, .blackFont)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
@@ -216,7 +216,9 @@ extension MyFeedView {
 
             feedStackView.topAnchor.constraint(equalTo: myFeedStackView.topAnchor, constant: 12),
             feedStackView.leftAnchor.constraint(equalTo: myFeedStackView.leftAnchor, constant: 16),
-            feedStackView.rightAnchor.constraint(equalTo: myFeedStackView.rightAnchor, constant: -16),
+            feedStackView.rightAnchor.constraint(equalTo: myFeedStackView.rightAnchor, constant: -16), // 이거 왜 안먹죠? ㅜㅜ
+            feedSectionTitleView.rightAnchor.constraint(equalTo: myFeedStackView.rightAnchor, constant: -16),
+            questionStackView.rightAnchor.constraint(equalTo: myFeedStackView.rightAnchor, constant: -16),
             
             artworkStackView.leftAnchor.constraint(equalTo: myFeedStackView.leftAnchor),
             artworkStackView.rightAnchor.constraint(equalTo: myFeedStackView.rightAnchor),

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewController.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewController.swift
@@ -1,0 +1,34 @@
+//
+//  MyFeedViewController.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/11/23.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+final class MyFeedViewController: UIViewController {
+    
+    private let myFeedView: MyFeedView = .init(artwork: .mockData, artworkDescription: .mockData, artworkReview: .mockData, highlights: [])
+    private let viewModel: MyFeedViewModel = MyFeedViewModel(fetchArtworkReviewUseCase: RealFetchArtworkReviewUseCase(),
+                                                             fetchArtworkDescriptionUseCase: RealFetchArtworkDescriptionUseCase(),
+                                                             fetchHighlightUseCase: RealFetchHighlightUseCase())
+    private let disposebag: DisposeBag = .init()
+    
+    override func loadView() {
+        super.loadView()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+    }
+    
+}
+


### PR DESCRIPTION
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.
🔒 Close #90

## 작업 내용 (Content)

![ezgif com-gif-maker](https://user-images.githubusercontent.com/59136391/203887013-031502fb-e50a-49b9-93b3-ff2cc7f6c0b7.gif)
- MyFeedView를 만들어 Artwork, ArtworkReview, ArtworkDescription을 불러와서 유저에게 보여줍니다.
- 자주 사용되는 컴포넌트로 SectionTitleView를 만들었습니다.
  - Section의 타이틀과 Divider를 하나로 가지고 있습니다.
  - `private lazy var feedSectionTitleView: SectionTitleView = .init(title: "\(artwork.id)번째 티라미술")` 이렇게 사용하면
  - <img width="242" alt="Screenshot 2022-11-25 at 10 18 55" src="https://user-images.githubusercontent.com/59136391/203881657-cf04d91c-b53d-4783-9647-5987d76368da.png">


- 피그마에 디자인 시스템 섹션에 Typography를 정리해놨습니다.
  - <img width="586" alt="Screenshot 2022-11-25 at 11 08 00" src="https://user-images.githubusercontent.com/59136391/203886016-888f8752-dfab-4dd8-a275-4af2dd7edbb3.png">
  - Typography enum을 만들었습니다.
- 디자인 시안에 모든 TextStyle이 적용되어 있으니 UI 구현하실 때 참고하시고, 적용해주시면 됩니다.
  - 이 과정을 편하게 하기 위해서 UILabel extension으로 `.textStyle(_:_:)`을 구현했습니다.
  - `label.textStyle(.Body1, .blackFont)` 이런 방식으로 typography와 color를 파라미터로 넘겨서 사용하시면 됩니다.


## Review points
- [텍스트 스타일을 간편하게 적용하는  UILabel extension으로 `.textStyle(_:_:)`을 구현](https://github.com/DeveloperAcademy-POSTECH/MacC_Team_Beartear/pull/110/files#diff-b81840619faca3935b3c0886065b39049244d6b274062a97a1972f3c34ccf88aR10-R43)
- [오토레이아웃이 제대로 적용이 안되는데 이유 좀 알려주세요.](https://github.com/DeveloperAcademy-POSTECH/MacC_Team_Beartear/pull/110/files#diff-9f3242150861daba50d1361efb89acc8e3803774b775b722fd9c73d2bad203bdR219)

## 기타 사항 (Etc)
- 작업하면서 고민이 되었던 부분이나 질문 사항 등

## 관련 사진 gif 및 (Optional)

## References (Optional)
- 참고한 사이트나 정리한 wiki 링크를 넣어주세요
- [링크이름](링크)
