### PR TITLE
[Feature] #102: lastArtworkId 이전의 questionAnswer들을 DB에서 불러온다. 

### DIFF
--- a/Gom4ziz/Source/Constants/CollectionName.swift
+++ b/Gom4ziz/Source/Constants/CollectionName.swift
@@ -16,6 +16,10 @@ enum CollectionName {
     static var artwork: String {
         ProcessInfo().isRunningTests ? "TestArtworks": "Artworks"
     }
+    
+    static var questionAnswer: String {
+        ProcessInfo().isRunningTests ? "TestQuestionAnswers": "QuestionAnswers"
+    }
 
     static var artworkDescription: String {
         ProcessInfo().isRunningTests ? "TestArtworkDescriptions": "ArtworkDescriptions"

--- a/Gom4ziz/Source/Data/Repository/FirebaseQuestionAnswerRepository.swift
+++ b/Gom4ziz/Source/Data/Repository/FirebaseQuestionAnswerRepository.swift
@@ -22,14 +22,13 @@ struct FirebaseQuestionAnswerRepository {
 // MARK: - QuestionAnswerRepository protocol extension
 extension FirebaseQuestionAnswerRepository: QuestionAnswerRepository {
     func fetchQuestionAnswerList(for userId: String, before artworkId: Int) -> Observable<[QuestionAnswer]> {
-        var returnQuestionAnswer: Observable<[QuestionAnswer]> = Observable.empty()
-        for artworkId in 1...artworkId {
-            let questionAnswer = Observable<QuestionAnswer>.zip([getQuestionAnswerListRef(for: userId, before: artworkId)
-                    .rx
-                    .decodable(as: QuestionAnswer.self)])
-            returnQuestionAnswer = returnQuestionAnswer.concat(questionAnswer)
+        var questionAnswerObservableList: [Observable<QuestionAnswer>] = []
+        for i in 1...artworkId {
+            questionAnswerObservableList.append(getQuestionAnswerListRef(for: userId, before: i)
+                .rx
+                .decodable(as: QuestionAnswer.self))
         }
-        return returnQuestionAnswer
+        return Observable.zip(questionAnswerObservableList) { $0 }
     }
 }
 

--- a/Gom4ziz/Source/Data/Repository/FirebaseQuestionAnswerRepository.swift
+++ b/Gom4ziz/Source/Data/Repository/FirebaseQuestionAnswerRepository.swift
@@ -24,17 +24,17 @@ extension FirebaseQuestionAnswerRepository: QuestionAnswerRepository {
     func fetchQuestionAnswerList(for userId: String, before artworkId: Int) -> Observable<[QuestionAnswer]> {
         var questionAnswerObservableList: [Observable<QuestionAnswer>] = []
         for i in 1...artworkId {
-            questionAnswerObservableList.append(getQuestionAnswerListRef(for: userId, before: i)
+            questionAnswerObservableList.append(getQuestionAnswerRef(for: userId, before: i)
                 .rx
                 .decodable(as: QuestionAnswer.self))
         }
-        return Observable.zip(questionAnswerObservableList) { $0 }
+        return Observable.zip(questionAnswerObservableList)
     }
 }
 
 // MARK: - private extension
 extension FirebaseQuestionAnswerRepository {
-    private func getQuestionAnswerListRef(for userId: String, before artworkId: Int) -> DocumentReference {
+    private func getQuestionAnswerRef(for userId: String, before artworkId: Int) -> DocumentReference {
         db
             .collection(CollectionName.artwork)
             .document(String(artworkId))

--- a/Gom4ziz/Source/Data/Repository/FirebaseQuestionAnswerRepository.swift
+++ b/Gom4ziz/Source/Data/Repository/FirebaseQuestionAnswerRepository.swift
@@ -1,0 +1,46 @@
+//
+//  FirebaseQuestionAnswerRepository.swift
+//  Gom4ziz
+//
+//  Created by 이가은 on 2022/11/24.
+//
+
+import Foundation
+
+import FirebaseFirestore
+import RxSwift
+
+protocol QuestionAnswerRepository {
+    func fetchQuestionAnswerList(for userId: String, before artworkId: Int) -> Observable<[QuestionAnswer]>
+}
+
+struct FirebaseQuestionAnswerRepository {
+    static let shared = FirebaseQuestionAnswerRepository()
+    private let db: Firestore = Firestore.firestore()
+}
+
+// MARK: - QuestionAnswerRepository protocol extension
+extension FirebaseQuestionAnswerRepository: QuestionAnswerRepository {
+    func fetchQuestionAnswerList(for userId: String, before artworkId: Int) -> Observable<[QuestionAnswer]> {
+        var returnQuestionAnswer: Observable<[QuestionAnswer]> = Observable.empty()
+        for artworkId in 1...artworkId {
+            let questionAnswer = Observable<QuestionAnswer>.zip([getQuestionAnswerListRef(for: userId, before: artworkId)
+                    .rx
+                    .decodable(as: QuestionAnswer.self)])
+            returnQuestionAnswer = returnQuestionAnswer.concat(questionAnswer)
+        }
+        return returnQuestionAnswer
+    }
+}
+
+// MARK: - private extension
+extension FirebaseQuestionAnswerRepository {
+    private func getQuestionAnswerListRef(for userId: String, before artworkId: Int) -> DocumentReference {
+        db
+            .collection(CollectionName.artwork)
+            .document(String(artworkId))
+            .collection(CollectionName.questionAnswer)
+            .document(String(userId))
+    }
+}
+

--- a/Gom4ziz/Source/Domain/UseCase/FetchQuestionAnswerUsecase.swift
+++ b/Gom4ziz/Source/Domain/UseCase/FetchQuestionAnswerUsecase.swift
@@ -1,0 +1,27 @@
+//
+//  FetchQuestionAnswerUsecase.swift
+//  Gom4ziz
+//
+//  Created by 이가은 on 2022/11/25.
+//
+
+import UIKit
+
+import RxSwift
+
+protocol FetchQuestionAnswerUsecase {
+    func fetchQuestionAnswerList(for userId: String, before artworkId: Int) -> Observable<[QuestionAnswer]>
+}
+
+struct RealFetchQuestionAnswerUsecase: FetchQuestionAnswerUsecase {
+    
+    private let questionAnswerRepository: QuestionAnswerRepository
+    
+    init(questionAnswerRepository: QuestionAnswerRepository = FirebaseQuestionAnswerRepository.shared) {
+        self.questionAnswerRepository = questionAnswerRepository
+    }
+    
+    func fetchQuestionAnswerList(for userId: String, before artworkId: Int) -> RxSwift.Observable<[QuestionAnswer]> {
+        questionAnswerRepository.fetchQuestionAnswerList(for: userId, before: artworkId)
+    }
+}


### PR DESCRIPTION
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.
🔒 Close #102

## 작업 내용 (Content)
- 작업한 내용을 나열 후 설명
- #102 이슈 참고해주세요 !
- #99 이후 lastArtworkId 이전의 questionAnswer들도 DB에서 불러오는 작업이 추가적으로 필요했습니다.
- 그래서 lastArtworkId 이전의 questionAnswer들을 DB에서 불러오는 QuestionAnswerRepository과 FetchQuestionAnswerUsecase을 구현했습니다 ..!

## Review points
- 리뷰어가 중점적으로 리뷰해줬으면 하는 포인트
- 하단의 기타 사항 참고

## 기타 사항 (Etc)
- 작업하면서 고민이 되었던 부분이나 질문 사항 등
- Artworks의 subCollection, QuestionAnswers에 접근을 해서 가지고 온 questionAnswer을 list 합쳐야 하는 과정에서 어려움이 있었습니다.
<img width="830" alt="스크린샷 2022-11-25 오전 11 32 38" src="https://user-images.githubusercontent.com/82457928/203888705-cdce98c3-8b7b-481a-8caf-004b4d9abfcf.png">
Zip이라는 operator를 써서 구현을 했는데, 이게 가장 좋은 방법이었는지 잘 모르겠습니다. 더 좋은 방법이 있다면 알려주세요..!
<img width="691" alt="스크린샷 2022-11-25 오전 11 34 45" src="https://user-images.githubusercontent.com/82457928/203888978-e5a5c98f-6414-4901-9d35-06b096a9a77b.png">

## 관련 사진 gif 및 (Optional)

## References (Optional)
- 참고한 사이트나 정리한 wiki 링크를 넣어주세요
