### PR TITLE
Typography 관련 extension 을 수정하고, 기존 컴포넌트에 타이포를 적용했습니다. 또한 SectionTitleView를 리팩토링했습니다.

### DIFF
--- a/Gom4ziz/Source/Constants/Typography.swift
+++ b/Gom4ziz/Source/Constants/Typography.swift
@@ -23,7 +23,7 @@ enum Typohgraphy {
 }
 
 extension Typohgraphy {
-    var toValue: (CGFloat, CGFloat, UIFont.Weight) {
+    var toValue: (fontSize: CGFloat, lineHieightMultiple: CGFloat, UIFont.Weight) {
         switch self {
         case .Display1: return (28, 1.5, .bold)
         case .Display2: return (24, 1.5, .bold)
@@ -32,7 +32,7 @@ extension Typohgraphy {
         case .Headline1: return (17, 1.4, .bold)
         case .Headline2: return (16, 1.2, .heavy)
         case .SubHeadline: return (16, 1.2, .medium)
-        case .Body1: return (18, 1.8, .light)
+        case .Body1: return (18, 1.5, .light)
         case .Body2: return (14, 1.5, .light)
         case .Caption: return (14, 1.5, .bold)
         case .NavigationTitle: return (16, 1.5, .semibold)

--- a/Gom4ziz/Source/Extension/Color.swift
+++ b/Gom4ziz/Source/Extension/Color.swift
@@ -9,8 +9,10 @@ import UIKit
 
 extension UIColor {
     static let blackFont: UIColor = UIColor(named: "BlackFont")!
+    static let gray1: UIColor = UIColor(named: "Gray1")!
     static let gray2: UIColor = UIColor(named: "Gray2")!
-    static let highlight: UIColor = UIColor(named: "Highlight")!
+    static let gray3: UIColor = UIColor(named: "Gray3")!
     static let gray4: UIColor = UIColor(named: "Gray4")!
+    static let highlight: UIColor = UIColor(named: "Highlight")!
     static let primary: UIColor = UIColor(named: "Primary")!
 }

--- a/Gom4ziz/Source/Extension/UILabel+TextStyle.swift
+++ b/Gom4ziz/Source/Extension/UILabel+TextStyle.swift
@@ -8,36 +8,46 @@
 import UIKit
 
 extension UILabel {
-    func textStyle(_ typography: Typohgraphy, _ color: UIColor) {
+    func textStyle(
+    _ typography: Typohgraphy,
+    kernValue: Double = 0,
+    lineSpacing: CGFloat = 0,
+    lineHeightMultiple: CGFloat? = nil,
+    alignment: NSTextAlignment = .left,
+    _ color: UIColor) {
         let (fontSize, lineheight, fontWeight) = typography.toValue
         self.font = .systemFont(ofSize: fontSize, weight: fontWeight)
-        self.setLineSpacing(lineSpacing: lineheight)
+        let lineHeight: CGFloat = lineHeightMultiple ?? lineheight
+        setLineSpacing(kernValue: kernValue, lineSpacing: lineSpacing, lineHeightMultiple: lineHeight, alignment: alignment)
         self.textColor = color
     }
     
-    func setLineSpacing(kernValue: Double = 0.0,
-                          lineSpacing: CGFloat = 0.0,
-                          lineHeightMultiple: CGFloat = 0.0) {
-          guard let labelText = self.text else { return }
-          
-          let paragraphStyle = NSMutableParagraphStyle()
-          paragraphStyle.lineSpacing = lineSpacing
-          paragraphStyle.lineHeightMultiple = lineHeightMultiple
-          
-          let attributedString: NSMutableAttributedString
-          if let labelAttributedText = self.attributedText {
-              attributedString = NSMutableAttributedString(attributedString: labelAttributedText)
-          } else {
-              attributedString = NSMutableAttributedString(string: labelText)
-          }
-          
-          attributedString.addAttribute(NSAttributedString.Key.paragraphStyle,
-                                        value: paragraphStyle,
-                                        range: NSMakeRange(0, attributedString.length))
-          attributedString.addAttribute(NSAttributedString.Key.kern,
-                                        value: kernValue,
-                                        range: NSMakeRange(0, attributedString.length))
-          
-          self.attributedText = attributedString
-      }
+    func setLineSpacing(
+        kernValue: Double = 0.0,
+        lineSpacing: CGFloat = 0.0,
+        lineHeightMultiple: CGFloat = 0.0,
+        alignment: NSTextAlignment = .left) {
+            guard let labelText = self.text else { return }
+
+            let paragraphStyle = NSMutableParagraphStyle()
+            paragraphStyle.lineSpacing = lineSpacing
+            paragraphStyle.lineHeightMultiple = lineHeightMultiple
+            paragraphStyle.alignment = alignment
+
+            let attributedString: NSMutableAttributedString
+            if let labelAttributedText = self.attributedText {
+                attributedString = NSMutableAttributedString(attributedString: labelAttributedText)
+            } else {
+                attributedString = NSMutableAttributedString(string: labelText)
+            }
+
+            attributedString.addAttribute(NSAttributedString.Key.paragraphStyle,
+                                          value: paragraphStyle,
+                                          range: NSRange(location: 0, length: attributedString.length))
+            attributedString.addAttribute(NSAttributedString.Key.kern,
+                                          value: kernValue,
+                                          range: NSRange(location: 0, length: attributedString.length))
+
+            self.attributedText = attributedString
+        }
 }

--- a/Gom4ziz/Source/Extension/UITextView+TextStyle.swift
+++ b/Gom4ziz/Source/Extension/UITextView+TextStyle.swift
@@ -9,23 +9,33 @@ import UIKit
 
 extension UITextView {
     
-    func textStyle(_ typography: Typohgraphy, _ color: UIColor) {
+    func textStyle(
+        _ typography: Typohgraphy,
+        _ color: UIColor
+    ) {
         let (fontSize, lineheight, fontWeight) = typography.toValue
         self.font = .systemFont(ofSize: fontSize, weight: fontWeight)
-        self.setTypingAttributes(lineSpacing: lineheight)
+        self.setTypingAttributes(lineHeightMultiple: lineheight)
         self.textColor = color
     }
     
-    func setTypingAttributes(kernValue: Double = 0.0,
-                        lineSpacing: CGFloat = 0.0,
-                        lineHeightMultiple: CGFloat = 0.0) {
+    func setTypingAttributes(
+        kernValue: Double = 0.0,
+        lineSpacing: CGFloat = 0.0,
+        lineHeightMultiple: CGFloat = 0.0) {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = lineSpacing
         paragraphStyle.lineHeightMultiple = lineHeightMultiple
-        
         let attributes: [NSAttributedString.Key: Any] = [.kern: -0.6,
                                                          .paragraphStyle: paragraphStyle]
         self.typingAttributes = attributes
+
+        guard attributedText.length > 0 else {
+            return
+        }
+        let willSet: NSMutableAttributedString = .init(attributedString: attributedText)
+        willSet.addAttributes(attributes, range: NSRange(location: 0, length: willSet.length - 1))
+        self.attributedText = willSet
     }
     
 }

--- a/Gom4ziz/Source/Presenter/ArtworkIntroduction/ArtworkIntroductionModal.swift
+++ b/Gom4ziz/Source/Presenter/ArtworkIntroduction/ArtworkIntroductionModal.swift
@@ -189,8 +189,7 @@ private extension ArtworkIntroductionModal {
 
     func setUpArtistLabel() {
         artistLabel.text = artwork.artist
-        // TODO: Gray3 으로 변경해야함
-        artistLabel.textStyle(.Body2, .gray2)
+        artistLabel.textStyle(.Body2, .gray3)
     }
 
     func setUpKeyboardObserver() {

--- a/Gom4ziz/Source/Presenter/Component/BubbleButton.swift
+++ b/Gom4ziz/Source/Presenter/Component/BubbleButton.swift
@@ -38,7 +38,9 @@ private extension BubbleButton {
 
     func setUpUI(text: String) {
         var configuration: Configuration = .filled()
-        configuration.title = text
+        var attributedString: AttributedString = AttributedString(stringLiteral: text)
+        attributedString.font = .systemFont(ofSize: 16, weight: .regular)
+        configuration.attributedTitle = attributedString
         configuration.background.backgroundColor = .gray4
         self.configuration = configuration
     }

--- a/Gom4ziz/Source/Presenter/Component/HighlightedTextView.swift
+++ b/Gom4ziz/Source/Presenter/Component/HighlightedTextView.swift
@@ -289,7 +289,6 @@ private extension HighlightedTextView {
     }
 
     func setUpTextView() {
-        textView.font = .systemFont(ofSize: 18, weight: .light)
         textView.text = text
         textView.isEditable = false
         textView.isScrollEnabled = false
@@ -298,6 +297,7 @@ private extension HighlightedTextView {
         textView.backgroundColor = .clear
         textView.textContainer.lineFragmentPadding = 0
         textView.textContainerInset = .init(top: 0, left: 0, bottom: 0, right: 0)
+        textView.textStyle(.Body1, .gray4)
         textView.linkTextAttributes = [
             .backgroundColor: highlightColor,
             .foregroundColor: highlightTextColor

--- a/Gom4ziz/Source/Presenter/Component/PlaceholderTextView.swift
+++ b/Gom4ziz/Source/Presenter/Component/PlaceholderTextView.swift
@@ -66,7 +66,7 @@ private extension PlaceholderTextView {
     func setUpConstraints() {
         placeholder.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            placeholder.topAnchor.constraint(equalTo: topAnchor, constant: 12),
+            placeholder.topAnchor.constraint(equalTo: topAnchor, constant: 0),
             placeholder.leftAnchor.constraint(equalTo: leftAnchor, constant: 12),
         ])
     }
@@ -79,13 +79,13 @@ private extension PlaceholderTextView {
     func setUpTextView() {
         layer.borderColor = UIColor.gray2.cgColor
         layer.borderWidth = 1
-        font = .systemFont(ofSize: 16, weight: .medium)
-        textContainerInset = .init(top: 12, left: 7, bottom: 0, right: 0)
+        textContainerInset = .init(top: 0, left: 8, bottom: 0, right: 0)
+        textStyle(.Body1, .gray4)
     }
 
     func setUpPlaceholder() {
         placeholder.textColor = .gray
-        placeholder.font = .systemFont(ofSize: 16, weight: .medium)
+        placeholder.textStyle(.Body1, .gray3)
     }
 
 }
@@ -111,7 +111,7 @@ struct PlaceholderTextViewPreview: PreviewProvider {
         Group {
             PlaceholderTextView(
                 placeholder: "플레이스홀더입니다.",
-                text: "텍스트입니다."
+                text: "플레이스홀더아닙니다."
             )
             .toPreview()
             .padding()

--- a/Gom4ziz/Source/Presenter/Component/SectionTitleView.swift
+++ b/Gom4ziz/Source/Presenter/Component/SectionTitleView.swift
@@ -7,71 +7,37 @@
 
 import UIKit
 
-final class SectionTitleView: BaseAutoLayoutUIView {
-    
-    let title: String
-    
-    private lazy var sectionTitleLabel: UILabel = {
-        let label = UILabel()
-        label.text = title
-        label.textStyle(.Headline2, .blackFont)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-    
-    private let sectionTitleDividerView: UIView = {
-        let divider = UIView()
-        divider.backgroundColor = .blackFont
-        divider.translatesAutoresizingMaskIntoConstraints = false
-        return divider
-    }()
-    
-    private lazy var sectionTitleStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [sectionTitleLabel,
-                                                       sectionTitleDividerView])
-        stackView.axis = .vertical
-        stackView.distribution = .fill
-        stackView.alignment = .fill
-        stackView.spacing = 8
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        return stackView
-    }()
+final class SectionTitleView: UILabel {
     
     init(title: String) {
-        self.title = title
         super.init(frame: .zero)
+        self.text = title
+        self.textStyle(.Headline2, alignment: .left, UIColor.gray4)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-}
 
-extension SectionTitleView {
-    
-    func addSubviews() {
-        self.addSubview(sectionTitleStackView)
+    /// 아래쪽에 underline을 추가한다.
+    /// - Parameter rect: Label을 그릴 영역
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        let dividerLayer: CALayer = CALayer()
+        dividerLayer.frame = CGRect(x: 0, y: rect.maxY - 2, width: rect.width, height: 2)
+        dividerLayer.backgroundColor = UIColor.gray4.cgColor
+        layer.insertSublayer(dividerLayer, at: 0)
     }
-    
-    func setUpConstraints() {
-        NSLayoutConstraint.activate([
-            sectionTitleStackView.topAnchor.constraint(equalTo: self.topAnchor),
-            sectionTitleStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            sectionTitleStackView.leftAnchor.constraint(equalTo: self.leftAnchor),
-            sectionTitleStackView.rightAnchor.constraint(equalTo: self.rightAnchor),
-            
-            sectionTitleLabel.topAnchor.constraint(equalTo: sectionTitleStackView.topAnchor),
-            
-            sectionTitleDividerView.leftAnchor.constraint(equalTo: sectionTitleLabel.leftAnchor),
-            sectionTitleDividerView.rightAnchor.constraint(equalTo: sectionTitleLabel.rightAnchor),
-            sectionTitleDividerView.bottomAnchor.constraint(equalTo: sectionTitleStackView.bottomAnchor),
-            sectionTitleDividerView.heightAnchor.constraint(equalToConstant: 2)
-        ])
+
+    /// Text는 원래 그리던 위치에 그대로 그린다 (본질적인 크기를 늘린 만큼 bottom inset을 준다
+    /// - Parameter rect: rect
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: .init(top: 0, left: 0, bottom: 9, right: 0)))
     }
-    
-    func setUpUI() {
-        self.backgroundColor = .white
+
+    /// UILabel의 본질적인 크기에서 height 를 8만큼 늘린다
+    override var intrinsicContentSize: CGSize {
+        let superSize = super.intrinsicContentSize
+        return CGSize(width: superSize.width, height: superSize.height + 9)
     }
-    
 }

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerView.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerView.swift
@@ -12,10 +12,9 @@ import RxSwift
 
 final class QuestionAnswerView: BaseAutoLayoutUIView {
 
-    private let divider: UIView = UIView()
     private let artwork: Artwork
     private let questionView: QuestionView
-    private let myThinkLabel: UILabel = UILabel()
+    private let myThinkLabel: SectionTitleView = SectionTitleView(title: "나의 생각")
     private let disposeBag: DisposeBag = .init()
     let answerInputTextView: PlaceholderTextView = .init(placeholder: "내용을 입력하세요")
 
@@ -35,7 +34,6 @@ final class QuestionAnswerView: BaseAutoLayoutUIView {
 extension QuestionAnswerView {
 
     func addSubviews() {
-        addSubview(divider)
         addSubview(questionView)
         addSubview(myThinkLabel)
         addSubview(answerInputTextView)
@@ -53,44 +51,26 @@ extension QuestionAnswerView {
         myThinkLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             myThinkLabel.leftAnchor.constraint(equalTo: questionView.leftAnchor),
-            myThinkLabel.topAnchor.constraint(equalTo: questionView.bottomAnchor, constant: 20)
-        ])
-
-        divider.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            divider.leftAnchor.constraint(equalTo: questionView.leftAnchor),
-            divider.rightAnchor.constraint(equalTo: questionView.rightAnchor),
-            divider.topAnchor.constraint(equalTo: myThinkLabel.bottomAnchor, constant: 8),
-            divider.heightAnchor.constraint(equalToConstant: 2),
+            myThinkLabel.topAnchor.constraint(equalTo: questionView.bottomAnchor, constant: 20),
+            myThinkLabel.rightAnchor.constraint(equalTo: questionView.rightAnchor)
         ])
 
         answerInputTextView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             answerInputTextView.leftAnchor.constraint(equalTo: questionView.leftAnchor),
             answerInputTextView.rightAnchor.constraint(equalTo: questionView.rightAnchor),
-            answerInputTextView.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: 20),
+            answerInputTextView.topAnchor.constraint(equalTo: myThinkLabel.bottomAnchor, constant: 20),
             answerInputTextView.bottomAnchor.constraint(equalTo: keyboardLayoutGuide.topAnchor, constant: -16)
         ])
     }
 
     func setUpUI() {
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTapGesture(sender:))))
-        setUpDivider()
-        setUpMyThinkLabel()
     }
 
 }
 
 private extension QuestionAnswerView {
-
-    func setUpDivider() {
-        divider.backgroundColor = .black
-    }
-
-    func setUpMyThinkLabel() {
-        myThinkLabel.text = "나의 생각"
-        myThinkLabel.font = .systemFont(ofSize: 15, weight: .black)
-    }
 
     /// 유저가 화면을 탭할 경우, 키보드를 숨깁니다.
     /// - Parameter sender: 제스쳐 식별기

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionView.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionView.swift
@@ -130,8 +130,8 @@ private extension QuestionView {
 
     func setUpQuestionNumberLabel() {
         questionNumberLabel.text = "\(artwork.id)번째 티라미술"
-        questionNumberLabel.font = .systemFont(ofSize: 14, weight: .bold)
         questionNumberLabel.textColor = .white
+        questionNumberLabel.textStyle(.Caption, .white)
     }
 
     func setUpQuestionLabel() {
@@ -140,7 +140,7 @@ private extension QuestionView {
         questionLabel.textColor = .white
         questionLabel.numberOfLines = 0
         questionLabel.lineBreakMode = .byWordWrapping
-        questionLabel.font = .systemFont(ofSize: 22, weight: .bold)
+        questionLabel.textStyle(.Display3, lineHeightMultiple: 1.26, alignment: .center, .white)
     }
 
     func setUpQuestionImageView() {

--- a/Gom4ziz/Source/System/SceneDelegate.swift
+++ b/Gom4ziz/Source/System/SceneDelegate.swift
@@ -51,10 +51,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        guard let url = URLContexts.first?.url else {
-            return
-        }
-        print(URLContexts)
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
## 작업 내용 (Content)
- Typo 관련 Extension을 수정했습니다! 이유는 다음과 같습니다.
1. 같은 타이포라도, 행간이 다른 Label들이 있다.
2. 또한 attributedText를 사용할 경우, 기존 textAlignment 속성은 먹지 않는다. 따라서 AttributedString전용 alignment를 설정할 필요가 있다.
3. 따라서 커닝, 라인스페이싱, 행간, 텍스트 정렬 등의 파라미터를 추가로 받을 수 있도록 API 를 수정했습니다.

<img src ="https://user-images.githubusercontent.com/57793298/204116795-6ed49453-97cf-4a21-8941-2caa420ed8d4.png" width = 200>

예를 들어 위 사진의 Typo 는 **Display3** 이지만, lineHeightMultiple 은 Typo의 값인 1.5가 아닌 1.26 입니다.

- 기존 UI Component들이 Typo 를 적용하도록 리팩토링했습니다.
- 또한 기존 UI Component들을 조금씩 수정했습니다.
- SectionTitleView를 리팩토링했습니다.

## Review points
- [SectionTitleView 리팩토링](https://github.com/DeveloperAcademy-POSTECH/MacC_Team_Beartear/compare/develop...DeveloperAcademy-POSTECH:Refactor%2FApplying_typography?expand=1#diff-586bf614747f32f165b8efae043dac8f82f332bc53d7c2b1a429155dad565044R12-R35)

![image](https://user-images.githubusercontent.com/57793298/204117197-943cfe73-2a6d-48f2-851d-ad151f034ae8.png)


- 먼저, UILabel을 화면에 그릴 때 (draw), 아래쪽에 디바이더를 추가합니다!
```swift
super.draw(rect)
let dividerLayer: CALayer = CALayer()
dividerLayer.frame = CGRect(x: 0, y: rect.maxY - 2, width: rect.width, height: 2)
dividerLayer.backgroundColor = UIColor.gray4.cgColor
layer.insertSublayer(dividerLayer, at: 0)
```

- 그러나 이렇게 될 경우, divider가 추가된 만큼 UILabel의 intrinsicContentSize도 늘어나야 합니다. 또한 divider가 UILabel과 너무 가깝기 때문에, text가 그려지는 CGRect는 기존대로 주고, divider만을 위한 추가 CGRect를 잡아야 합니다. 따라서 intrinsicContentSize를 override해 height를 9만큼 늘립니다. 왜 9만큼 늘리냐? text의 바닥과 divider 사이의 간격이 7이기 때문에, 7과 divider의 높이인 2를 더해서 9만큼 늘려줍니다.
```swift
 /// UILabel의 본질적인 크기에서 height 를 8만큼 늘린다
    override var intrinsicContentSize: CGSize {
        let superSize = super.intrinsicContentSize
        return CGSize(width: superSize.width, height: superSize.height + 9)
    }
```

- 기존 text가 그려지는 CGRect는 intrinsicContentSize를 재정의함으로써 늘어난 CGRect와 다르게, 원래대로 그려져야 합니다. 따라서, drawText 메소드를 오버라이드해서 원래 intrinsicContentSize만큼의 CGRect를 전달해줍니다.

```swift
// Text는 원래 그리던 위치에 그대로 그린다 (본질적인 크기를 늘린 만큼 bottom inset을 준다
    /// - Parameter rect: rect
    override func drawText(in rect: CGRect) {
        super.drawText(in: rect.inset(by: .init(top: 0, left: 0, bottom: 9, right: 0)))
    }
```

## 기타 사항 (Etc)
- SectionTitleView가 단순히 CALayer만 추가하게 리팩토링함으로써 성능 향상이 있을 것으로 예상됩니다! 단순 언더라인이나, 어떤 도형을 그려야 할 때 위와 같은 방법을 사용하면 아주 성능 좋게 컴포넌트들을 만들 수 있을 것 같아요

## References (Optional)
- [IntrinsicContentSize](https://developer.apple.com/documentation/uikit/uiview/1622600-intrinsiccontentsize)
- [UILabel에 padding 적용하기](https://jeonyeohun.tistory.com/248)
