### PR TITLE
[Feature] #123: DB에서 데이터를 불러오는데 실패했을 때, 보여줄 ErrorView를 추가했습니다.

### DIFF
--- a/Gom4ziz/Source/Constants/ErrorViewMessage.swift
+++ b/Gom4ziz/Source/Constants/ErrorViewMessage.swift
@@ -1,0 +1,13 @@
+//
+//  ErrorViewMessage.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/11/27.
+//
+
+import Foundation
+
+enum ErrorViewMessage: String {
+    case artwork = "작품을 불러오는데 실패했습니다."
+    case tiramisul = "티라미술을 불러오는데 실패했습니다."
+}

--- a/Gom4ziz/Source/Presenter/Component/ErrorView.swift
+++ b/Gom4ziz/Source/Presenter/Component/ErrorView.swift
@@ -9,9 +9,11 @@ import UIKit
 
 final class ErrorView: BaseAutoLayoutUIView {
     
-    enum ButtonSize: CGFloat {
-        case width = 154
-        case height = 48
+    private enum Size {
+        static let messageStackViewSpcing: CGFloat = 4
+        static let errorStackViewSpcing: CGFloat = 20
+        static let buttonWidth: CGFloat = 154
+        static let buttonHeight: CGFloat = 48
     }
     
     private let message: ErrorViewMessage
@@ -46,7 +48,7 @@ final class ErrorView: BaseAutoLayoutUIView {
         stackView.distribution = .fill
         stackView.alignment = .center
         stackView.axis = .vertical
-        stackView.spacing = 4
+        stackView.spacing = Size.messageStackViewSpcing
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
@@ -70,7 +72,7 @@ final class ErrorView: BaseAutoLayoutUIView {
         stackView.distribution = .fill
         stackView.alignment = .center
         stackView.axis = .vertical
-        stackView.spacing = 20
+        stackView.spacing = Size.errorStackViewSpcing
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
@@ -98,8 +100,8 @@ extension ErrorView {
             errorStackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
             errorStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
             
-            retryButton.widthAnchor.constraint(equalToConstant: ButtonSize.width.rawValue),
-            retryButton.heightAnchor.constraint(equalToConstant: ButtonSize.height.rawValue)
+            retryButton.widthAnchor.constraint(equalToConstant: Size.buttonWidth),
+            retryButton.heightAnchor.constraint(equalToConstant: Size.buttonHeight)
         ])
     }
     

--- a/Gom4ziz/Source/Presenter/Component/ErrorView.swift
+++ b/Gom4ziz/Source/Presenter/Component/ErrorView.swift
@@ -1,0 +1,119 @@
+//
+//  ErrorView.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/11/27.
+//
+
+import UIKit
+
+final class ErrorView: BaseAutoLayoutUIView {
+    
+    enum ButtonSize: CGFloat {
+        case width = 154
+        case height = 48
+    }
+    
+    private let message: ErrorViewMessage
+    private let isShowLogo: Bool
+    
+    private lazy var logoImageView: UIImageView = {
+        let imageView = UIImageView()
+        // TODO: 이미지 불러오는 로직 추가
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    private lazy var errorMessageLabel: UILabel = {
+        let label = UILabel()
+        label.text = message.rawValue
+        label.textStyle(.Title, .blackFont)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let captionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "아래 버튼을 탭해서 다시 불러와 보세요."
+        label.textStyle(.NavigationButton, .systemGray) // TODO: systemGray -> gray3
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var messageStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [errorMessageLabel,
+                                                       captionLabel])
+        stackView.distribution = .fill
+        stackView.alignment = .center
+        stackView.axis = .vertical
+        stackView.spacing = 4
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    lazy var retryButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.setTitle("탭하여 다시 시도 ↻", for: .normal)
+        button.titleLabel?.font = .boldSystemFont(ofSize: 12)
+        button.backgroundColor = .gray4
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    private lazy var errorStackView: UIStackView = {
+        let stackView = UIStackView()
+        if isShowLogo {
+            stackView.addArrangedSubview(logoImageView)
+        }
+        stackView.addArrangedSubview(messageStackView)
+        stackView.addArrangedSubview(retryButton)
+        stackView.distribution = .fill
+        stackView.alignment = .center
+        stackView.axis = .vertical
+        stackView.spacing = 20
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    init(message: ErrorViewMessage, isShowLogo: Bool = true) {
+        self.message = message
+        self.isShowLogo = isShowLogo
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+extension ErrorView {
+    
+    func addSubviews() {
+        self.addSubview(errorStackView)
+    }
+    
+    func setUpConstraints() {
+        NSLayoutConstraint.activate([
+            errorStackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            errorStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            
+            retryButton.widthAnchor.constraint(equalToConstant: ButtonSize.width.rawValue),
+            retryButton.heightAnchor.constraint(equalToConstant: ButtonSize.height.rawValue)
+        ])
+    }
+    
+    func setUpUI() {
+        
+    }
+    
+}
+
+#if DEBUG
+import SwiftUI
+struct ErrorViewPreview: PreviewProvider {
+    static var previews: some View {
+        ErrorView(message: .tiramisul, isShowLogo: false).toPreview()
+    }
+}
+#endif


### PR DESCRIPTION
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.
🔒 Close #123

## 작업 내용 (Content)
- DB에서 데이터를 불러오는데 실패했을 때, 보여줄 ErrorView를 추가했습니다.
- 사용 방법은
```swift
ErrorView(message: .tiramisul, isShowLogo: false) 
```
이런 식으로 사용합니다.
- ErrorView의 message는 정확한 의미전달과 케이스를 분기하기 위해서 ErrorViewMessage enum을 따로 만들었습니다.
  - 단순히 작품을 불러오는데 실패했을 경우는 `.artwork`로 처리하고, 그외의 모든 에러케이스는 `.tiramisul`로 처리합니다.
- `isShowLogo` 프로퍼티는 이름 그대로 로고를 보여줄 것인지 말 것인지를 선택하는 프로퍼티입니다.
- 탭하여 다시 불러오는 로직을 구현하실 때는, ViewController에서 rx.tap 로직을 활용해서 관련 데이터를 fetch하는 메서드를 호출하면 될 것입니다.


## Review points
- 리뷰어가 중점적으로 리뷰해줬으면 하는 포인트

## 기타 사항 (Etc)
- 작업하면서 고민이 되었던 부분이나 질문 사항 등

## 관련 사진 gif 및 (Optional)

## References (Optional)
- 참고한 사이트나 정리한 wiki 링크를 넣어주세요
- [링크이름](링크)
