### PR TITLE
[Feat]: 리뷰된 ArtworkList와 QuestionAnswerList를 불러오는 ReviewedArtworkListViewModel 구현

### DIFF
--- a/Gom4ziz/Source/Presenter/Main/ReviewedArtworkList/ReviewedArtworkListCellViewModel.swift
+++ b/Gom4ziz/Source/Presenter/Main/ReviewedArtworkList/ReviewedArtworkListCellViewModel.swift
@@ -1,0 +1,31 @@
+//
+//  ReviewedArtworkListCellViewModel.swift
+//  Gom4ziz
+//
+//  Created by 이가은 on 2022/11/28.
+//
+
+import Foundation
+
+/// ReviewedArtworkListCell 뷰를 위한 모델
+struct ReviewedArtworkListCellViewModel {
+    let artworkId: Int
+    let numberText: String
+    let question: String
+    let answer: String
+    let imageURLString: String
+    
+    init(artwork: Artwork, questionAnswer: QuestionAnswer) {
+        self.artworkId = artwork.id
+        self.numberText = "\(artwork.id)번째 티라미술"
+        self.question = artwork.question
+        self.answer = questionAnswer.questionAnswer
+        self.imageURLString = artwork.imageUrl
+    }
+}
+
+extension ReviewedArtworkListCellViewModel: CustomStringConvertible {
+    var description: String {
+        "\(numberText), 질문 : \(question), 답변: \(answer)"
+    }
+}

--- a/Gom4ziz/Source/Presenter/Main/ReviewedArtworkList/ReviewedArtworkListViewModel.swift
+++ b/Gom4ziz/Source/Presenter/Main/ReviewedArtworkList/ReviewedArtworkListViewModel.swift
@@ -1,0 +1,44 @@
+//
+//  ReviewedArtworkListViewModel.swift
+//  Gom4ziz
+//
+//  Created by 이가은 on 2022/11/28.
+//
+
+import Foundation
+
+import RxCocoa
+import RxSwift
+
+final class ReviewedArtworkListViewModel {
+    
+    private let fetchReviewedArtworkUsecase: FetchReviewedArtworkUsecase
+    private let fetchQuestionAnswerUsecase: FetchQuestionAnswerUsecase
+    
+    let reviewedArtworkListCellListObservable: BehaviorRelay<Loadable<[ReviewedArtworkListCellViewModel]>> = .init(value: .notRequested)
+    
+    private let disposeBag: DisposeBag = .init()
+    
+    init(fetchReviewedArtworkUsecase: FetchReviewedArtworkUsecase,
+         fetchQuestionAnswerUsecase: FetchQuestionAnswerUsecase) {
+        self.fetchReviewedArtworkUsecase = fetchReviewedArtworkUsecase
+        self.fetchQuestionAnswerUsecase = fetchQuestionAnswerUsecase
+    }
+    
+    func fetchReviewedArtworkListCellList(for userId: String, before artworkId: Int) {
+        reviewedArtworkListCellListObservable.accept(.isLoading(last: nil))
+        Observable.zip(fetchReviewedArtworkUsecase.requestReviewedArtworkList(before: artworkId), fetchQuestionAnswerUsecase.fetchQuestionAnswerList(for: userId, before: artworkId))
+            .map { (artworkList, questionAnswerList) in
+                Array(0..<artworkId).map {
+                    ReviewedArtworkListCellViewModel(artwork: artworkList[$0], questionAnswer: questionAnswerList[$0])
+                }
+            }
+            .subscribe(onNext: {
+                self.reviewedArtworkListCellListObservable.accept(.loaded($0))
+            }, onError: {
+                self.reviewedArtworkListCellListObservable.accept(.failed($0))
+            })
+            .disposed(by: disposeBag)
+    }
+    
+}

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedView.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedView.swift
@@ -13,7 +13,6 @@ final class MyFeedView: BaseAutoLayoutUIView {
     private let artworkDescription: ArtworkDescription
     private let questionAnswer: QuestionAnswer
     private let artworkReview: ArtworkReview
-    private let questionAnswer: QuestionAnswer
     private let highlights: [Highlight]
     
     // MARK: - UI Component
@@ -175,13 +174,11 @@ final class MyFeedView: BaseAutoLayoutUIView {
          artworkDescription: ArtworkDescription,
          questionAnswer: QuestionAnswer,
          artworkReview: ArtworkReview,
-         questionAnswer: QuestionAnswer,
          highlights: [Highlight]) {
         self.artwork = artwork
         self.artworkDescription = artworkDescription
         self.questionAnswer = questionAnswer
         self.artworkReview = artworkReview
-        self.questionAnswer = questionAnswer
         self.highlights = highlights
         super.init(frame: .zero)
         self.backgroundColor = .white
@@ -242,7 +239,7 @@ extension MyFeedView {
 import SwiftUI
 struct MyFeedViewPreview: PreviewProvider {
     static var previews: some View {
-        MyFeedView(artwork: .mockData, artworkDescription: .mockData, artworkReview: .mockData, questionAnswer: .mockData, highlights: []).toPreview()
+        MyFeedView(artwork: .mockData, artworkDescription: .mockData, questionAnswer: .mockData, artworkReview: .mockData, highlights: []).toPreview()
     }
 }
 #endif

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewController.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewController.swift
@@ -12,7 +12,7 @@ import RxSwift
 
 final class MyFeedViewController: UIViewController {
     
-    private let myFeedView: MyFeedView = .init(artwork: .mockData, artworkDescription: .mockData, artworkReview: .mockData, questionAnswer: .mockData, highlights: [])
+    private let myFeedView: MyFeedView = .init(artwork: .mockData, artworkDescription: .mockData, questionAnswer: .mockData, artworkReview: .mockData, highlights: [])
     private let viewModel: MyFeedViewModel = MyFeedViewModel(fetchArtworkReviewUseCase: RealFetchArtworkReviewUseCase(),
                                                              fetchArtworkDescriptionUseCase: RealFetchArtworkDescriptionUseCase(),
                                                              fetchHighlightUseCase: RealFetchHighlightUseCase())


### PR DESCRIPTION
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.
🔒 Close #112 

## 작업 내용 (Content)
- 작업한 내용을 나열 후 설명
- ReviewedArtworkListViewModel 구현
<img width="727" alt="스크린샷 2022-11-28 오후 8 20 29" src="https://user-images.githubusercontent.com/82457928/204265740-c2f6baa8-e3db-484f-b19c-70aab35f10a5.png">

- [x] ArtworRecordView가 load될 때 사용자가 리뷰한 Artwork와 QuestionAnswer을 DB에서 불러온다.

- [x] 둘 중 하나라도 실패하면 실패로 취급
- [x] 둘 다 load 완료시에 성공
-> @HoJongE 가 제안해주신 방법대로 구현했습니다. 감사합니다 :)
<img width="744" alt="스크린샷 2022-11-28 오후 8 40 18" src="https://user-images.githubusercontent.com/82457928/204268999-cbe13457-d89c-4446-a079-f7038255b627.png">

## Review points
- 리뷰어가 중점적으로 리뷰해줬으면 하는 포인트
- Launch Screen.storyboard 건들지도 않았고, xcode 상에서도 diff가 안 뜨는데 값이 달라져 있습니다.. 혹시 이유를 아시는 분이 있을까요 ?
- develop에서 pull 해오니까, MyFeedView에 questionAnswer가 2번 중복되어 파라매터로 들어가 있었습니다. merge하기 전에 확인을 한번 더 하면 좋을 것 같습니다 ☺️

## 기타 사항 (Etc)
- 작업하면서 고민이 되었던 부분이나 질문 사항 등

## 관련 사진 gif 및 (Optional)

## References (Optional)
- 참고한 사이트나 정리한 wiki 링크를 넣어주세요
- [zip 관련 디스커션 with @SH0123 ](https://github.com/DeveloperAcademy-POSTECH/MacC_Team_Beartear/discussions/131)
