### PR TITLE
Refactor: Fix QuestionAnswerView to show error view when failed to load

### DIFF
--- a/Gom4ziz/Source/Presenter/QuestionAnswer/ArtworkIntroduction/ArtworkIntroductionViewController.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/ArtworkIntroduction/ArtworkIntroductionViewController.swift
@@ -22,7 +22,7 @@ final class ArtworkIntroductionViewController: UIViewController {
         self.viewModel = viewModel
         self.artworkIntroductionView = ArtworkIntroductionView(
             artwork: viewModel.artwork,
-            artworkDescription: viewModel.artworkDescription!,
+            artworkDescription: viewModel.artworkDescriptionRelay.value.value!,
             review: viewModel.review.value,
             highlights: viewModel.highlights.value
         )

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionAnswerView.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionAnswerView.swift
@@ -49,6 +49,7 @@ extension QuestionAnswerView {
     }
 }
 
+// MARK: - 프로토콜 구현부
 extension QuestionAnswerView {
 
     func addSubviews() {

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionAnswerViewModel.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionAnswerViewModel.swift
@@ -17,9 +17,6 @@ final class QuestionAnswerViewModel {
     private let disposeBag: DisposeBag = .init()
     private let userId: String
     let artwork: Artwork
-    var artworkDescription: ArtworkDescription? {
-        artworkDescriptionRelay.value.value
-    }
     // MARK: - Rx Relays
     let artworkDescriptionRelay: BehaviorRelay<Loadable<ArtworkDescription>> = .init(value: .notRequested)
     let addEvent: BehaviorRelay<Loadable<Void>> = .init(value: .notRequested)

--- a/Gom4ziz/Source/System/SceneDelegate.swift
+++ b/Gom4ziz/Source/System/SceneDelegate.swift
@@ -23,7 +23,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         window?.makeKeyAndVisible()
         // 테스트를 위해서 루트 뷰컨트롤러를 변경할 수 있습니다.
-        testMyFeedView()
+        testQuestionAnswerView()
         changeStatusBarBgColor(bgColor: .white)
     }
     


### PR DESCRIPTION
## Close Issues
🔒 Close #159 

## 작업 내용 (Content)
- QuestionAnswerView에서 ArtworkDescription 로딩에 실패한 경우, ErrorView를 띄우도록 코드를 리팩토링 하였습니다.
- 또한 다음버튼 활성화 여부를 판단하는 stream을 리팩토링해, self참조 없이도 버튼의 활성화 여부를 반응적으로 변경할 수 있습니다.


## Review points
- 유저의 답변 입력 여부와, artworkDescription 로딩 성공 여부에 따라 다음화면으로 이동하는 버튼의 활성화 여부를 결정합니다.
- 따라서 유저 답변이 변경될 때나, artworkDescription의 로딩 여부가 변경될 때마다, 버튼의 활성화 여부를 변경해야 합니다 -> combineLatest 사용

이번 pr에서, 기존에 map 내부에서 self.viewModel참조에 따른 self 참조가 일어난 코드를, drive를 통해 self 참조를 없앴습니다.

**변경 전 코드**
```swift
questionAnswerView.answerInputTextView
            .rx
            .text
            .compactMap { $0 }
            .asDriver(onErrorJustReturn: "")
            .drive(onNext: { [unowned self] in
                // 만약 유저가 답변을 입력하고, artworkDescription이 존재한다면 다음 버튼이 활성화된다.
                if !$0.isEmpty && viewModel.artworkDescription != nil {
                    enableNextButton()
                    return
                }
                // 만약 유저가 답변을 입력하지 않았거나, artworkDescription이 불러와지지 않은 경우 다음 버튼이 비활성화된다.
                disableNextButton()
            })
            .disposed(by: disposeBag)
```
위 코드에선, 두 가지 relay, 즉 viewModel의 artworkDescription과 rx.text 스트림을 결합하지 않았었는데, 따라서 drive onNext 클로저 내부에서 self에 대한 unowned 참조가 발생했었습니다.

**변경 후 코드**

```swift
let answer = questionAnswerView
            .answerInputTextView
            .rx
            .text
            .orEmpty
            .asDriver()

        // 유저 답변 입력, 그리고 상세 정보 로딩 완료 여부 검사
        Driver
            .combineLatest(answer, viewModel.artworkDescriptionRelay.asDriver())
            .map { answer, artworkDescription in
                !answer.isEmpty && artworkDescription.value != nil
            }
            .drive(nextButton.rx.isEnabled)
```

변경 후 코드에서는, 답변 입력 스트림과, artworkDescription 스트림을 combineLatest로 결합하고, map 으로 구한 활성화 여부를 바로 button의 isEnabled 프로퍼티에 바인드 함으로써 self참조를 없앨 수 있었습니다. 또한 코드도 훨씬 간결해졌습니다.

## 기타 사항 (Etc)

## 관련 사진 gif 및 (Optional)
![Simulator Screen Recording - iPhone 13 - 2022-12-01 at 21 48 53](https://user-images.githubusercontent.com/57793298/205057617-23c90775-ce87-4e46-b44a-d1b0b4599c6e.gif)
