### PR TITLE
[Feature] #163: 감상 기록 화면에서 작품 이미지를 탭하면 확대/축소할 수 있도록 구현했습니다.

### DIFF
--- a/Gom4ziz/Source/Constants/ViewTag.swift
+++ b/Gom4ziz/Source/Constants/ViewTag.swift
@@ -1,0 +1,14 @@
+//
+//  ViewTag.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/12/02.
+//
+
+import Foundation
+
+enum ViewTag: Int {
+    case lottieView = 1
+    case errorView = 2
+    case zoomableImageView = 3
+}

--- a/Gom4ziz/Source/Extension/UIViewController+Loadble.swift
+++ b/Gom4ziz/Source/Extension/UIViewController+Loadble.swift
@@ -9,9 +9,9 @@ import UIKit
 
 extension UIViewController {
     
-    func setUpErrorView(_ message: ErrorViewMessage, _ isShowLogo: Bool, onRetryButtonTapped: @escaping () -> Void = { }) {
+    func showErrorView(_ message: ErrorViewMessage, _ isShowLogo: Bool, onRetryButtonTapped: @escaping () -> Void = { }) {
         let errorView: ErrorView = .init(message: message, isShowLogo: isShowLogo, onRetryButtonTapped: onRetryButtonTapped)
-        errorView.tag = 2
+        errorView.tag = ViewTag.errorView.rawValue
         self.view.addSubview(errorView)
         errorView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/Gom4ziz/Source/Extension/UIViewController+Lottie.swift
+++ b/Gom4ziz/Source/Extension/UIViewController+Lottie.swift
@@ -19,7 +19,7 @@ extension UIViewController {
         let lottieLoadingView: LottieAnimationView = LottieAnimationView(name: "spinner")
         lottieLoadingView.loopMode = .loop
         lottieLoadingView.backgroundColor = .black.withAlphaComponent(0.5)
-        lottieLoadingView.tag = 1004
+        lottieLoadingView.tag = ViewTag.lottieView.rawValue
         lottieLoadingView.frame = window.bounds
         window.addSubview(lottieLoadingView)
         lottieLoadingView.play()
@@ -29,7 +29,7 @@ extension UIViewController {
         let scenes = UIApplication.shared.connectedScenes
         let windowScene = scenes.first as? UIWindowScene
         guard let window = windowScene?.windows.first else { return }
-        window.viewWithTag(1004)?.removeFromSuperview()
+        window.viewWithTag(ViewTag.lottieView.rawValue)?.removeFromSuperview()
     }
 
 }

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedView.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedView.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol ZoomableDelegateProtocol {
+    func onImageViewTapped()
+}
+
 final class MyFeedView: BaseAutoLayoutUIView {
     
     private let artwork: Artwork
@@ -54,7 +58,7 @@ final class MyFeedView: BaseAutoLayoutUIView {
     
     // 작품 정보
     
-    private lazy var artworkImageView: AsyncImageView = .init(
+    lazy var artworkImageView: AsyncImageView = .init(
         url: artwork.imageUrl,
         contentMode: .scaleAspectFill)
     
@@ -152,6 +156,8 @@ final class MyFeedView: BaseAutoLayoutUIView {
         return stackView
     }()
     
+    var delegate: ZoomableDelegateProtocol?
+    
     init(artwork: Artwork,
          questionAnswer: QuestionAnswer) {
         self.artwork = artwork
@@ -209,7 +215,21 @@ extension MyFeedView {
     }
     
     func setUpUI() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(imageViewTapped))
+        artworkImageView.addGestureRecognizer(tap)
+        artworkImageView.isUserInteractionEnabled = true
+    }
+    
+}
 
+extension MyFeedView {
+    
+    func onImageViewTapped() {
+        delegate?.onImageViewTapped()
+    }
+    
+    @objc func imageViewTapped() {
+        onImageViewTapped()
     }
     
 }

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedView.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-protocol ZoomableDelegateProtocol {
+protocol ZoomableDelegateProtocol: AnyObject {
     func onImageViewTapped()
 }
 
@@ -156,7 +156,7 @@ final class MyFeedView: BaseAutoLayoutUIView {
         return stackView
     }()
     
-    var delegate: ZoomableDelegateProtocol?
+    weak var delegate: ZoomableDelegateProtocol?
     
     init(artwork: Artwork,
          questionAnswer: QuestionAnswer) {

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewController.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewController.swift
@@ -50,6 +50,7 @@ final class MyFeedViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        myFeedView.delegate = self
         setUpNavigationBar()
         setUpObservers()
         fetchMyFeedViewModel()
@@ -83,7 +84,7 @@ private extension MyFeedViewController {
                     self?.hideLottieLoadingView()
                 case .failed:
                     self?.hideLottieLoadingView()
-                    self?.setUpErrorView(.tiramisul, false) {
+                    self?.showErrorView(.tiramisul, false) {
                         self?.viewModel.fetchMyFeed(artworkId: (self?.artwork.id)!,
                                                     userId: (self?.user.id)!)
                     }
@@ -109,9 +110,15 @@ private extension MyFeedViewController {
 
 }
 
-// MARK: - Button Actions
+// MARK: - Tapped Actions
 
-private extension MyFeedViewController {
+extension MyFeedViewController: ZoomableDelegateProtocol {
+    
+    func onImageViewTapped() {
+        let vc = ZoomableImageViewController(url: artwork.imageUrl)
+        vc.modalPresentationStyle = .fullScreen
+        present(vc, animated: true)
+    }
     
     @objc func backButtonTapped() {
         dismiss(animated: true)

--- a/Gom4ziz/Source/Presenter/MyFeed/ZoomableImageViewController.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/ZoomableImageViewController.swift
@@ -1,0 +1,68 @@
+//
+//  ZoomableImageViewController.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/12/02.
+//
+
+import UIKit
+
+final class ZoomableImageViewController: UIViewController {
+    
+    enum Size: CGFloat {
+        case closeButtonSize = 40
+    }
+    
+    private let zoomableAsyncImageView: ZoomableAsyncImageView
+    private lazy var closeButton: UIButton = {
+        let button = UIButton(type: .close)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(onCloseButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    init(url: String) {
+        self.zoomableAsyncImageView = ZoomableAsyncImageView(url: url)
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUpUI()
+        setConstraints()
+    }
+    
+}
+
+private extension ZoomableImageViewController {
+    
+    func setUpUI() {
+        self.view.backgroundColor = .gray1
+        self.view.addSubview(zoomableAsyncImageView)
+        self.zoomableAsyncImageView.addSubview(closeButton)
+    }
+    
+    func setConstraints() {
+        zoomableAsyncImageView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            zoomableAsyncImageView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            zoomableAsyncImageView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            zoomableAsyncImageView.centerYAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.centerYAnchor),
+            zoomableAsyncImageView.widthAnchor.constraint(equalToConstant: self.view.bounds.width),
+            
+            closeButton.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+            closeButton.rightAnchor.constraint(equalTo: self.view.rightAnchor, constant: -16),
+            closeButton.widthAnchor.constraint(equalToConstant: Size.closeButtonSize.rawValue),
+            closeButton.heightAnchor.constraint(equalToConstant: Size.closeButtonSize.rawValue)
+        ])
+    }
+    
+    @objc func onCloseButtonTapped() {
+        dismiss(animated: true)
+    }
+    
+}

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionAnswerViewController.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionAnswerViewController.swift
@@ -74,7 +74,7 @@ private extension QuestionAnswerViewController {
                     self.focusOnTextView()
                 case .failed:
                     self.questionAnswerView.hideSkeletonUI()
-                    self.setUpErrorView(.artwork, true) {
+                    self.showErrorView(.artwork, true) {
                         self.viewModel.fetchArtworkDescription()
                     }
                 default: break


### PR DESCRIPTION
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.
🔒 Close #163

## 작업 내용 (Content)
- 감상 기록 화면에서 작품 이미지를 탭하면 확대/축소할 수 있도록 구현했습니다.
- MyFeedView에 있는 artworkImageView를 탭했을 때, ZoomableImageViewController로 present 되도록 구현했습니다.
- MyFeedView에서 UI event가 일어나고, UIViewController에서 present가 일어나야 해서 `ZoomableDeleagteProtocol`을 만들어서 delegate 패턴을 활용했습니다.
- UIViewController extension에 있는 setUpErrorView를 `showErrorView`로 변경했습니다.
- ViewTag enum을 만들어서 constants로 만들었습니다.


## Review points
- 리뷰어가 중점적으로 리뷰해줬으면 하는 포인트

## 기타 사항 (Etc)
- 작업하면서 고민이 되었던 부분이나 질문 사항 등

## 관련 사진 gif 및 (Optional)
![ezgif com-gif-maker-3](https://user-images.githubusercontent.com/59136391/205206432-ad7991a8-6ee7-4094-bcad-c5430c2a48ca.gif)

## References (Optional)
- 참고한 사이트나 정리한 wiki 링크를 넣어주세요
- [링크이름](링크)
