### PR TITLE
메인뷰에서 작품 리스트를 불러오는 동안, 로딩 스켈레톤 UI를 보여줍니다.

### DIFF
--- a/Gom4ziz/Source/Presenter/Component/AsyncImageView.swift
+++ b/Gom4ziz/Source/Presenter/Component/AsyncImageView.swift
@@ -36,6 +36,11 @@ final class AsyncImageView: UIImageView {
     required init?(coder: NSCoder) {
         fatalError()
     }
+
+    deinit {
+        previousDisposable?.dispose()
+    }
+
 }
 
 // MARK: - 퍼블릭 API

--- a/Gom4ziz/Source/Presenter/Main/ReviewedArtworkList/MainViewController.swift
+++ b/Gom4ziz/Source/Presenter/Main/ReviewedArtworkList/MainViewController.swift
@@ -60,7 +60,7 @@ final class MainViewController: UIViewController, UIScrollViewDelegate {
     }
     
     // row 데이터 적용 (section은 dataSource.titleForHeaderInSection으로 설정)
-    var dataSource = RxTableViewSectionedReloadDataSource<Section> { dataSource, tableView, indexPath, item in
+    var dataSource = RxTableViewSectionedReloadDataSource<Section> { _, tableView, indexPath, item in
         let cell = tableView.dequeueReusableCell(withIdentifier: "reviewedArtworkCell", for: indexPath) as! ReviewedArtworkCell
         cell.setViewModel(reviewedArtworkListCellViewModel: item)
         return cell
@@ -89,9 +89,7 @@ final class MainViewController: UIViewController, UIScrollViewDelegate {
         reviewdArtworkCellListDriver
             .drive(onNext: { [weak self] status in
                 switch status {
-                    case .notRequested:
-                        print("notRequested")
-                    case .failed(let error):
+                    case .failed:
                         self?.showErrorView(.reviewedArtwork, false) {
                             guard let user = self?.userViewModel.user else {
                               return
@@ -101,8 +99,8 @@ final class MainViewController: UIViewController, UIScrollViewDelegate {
                             self?.reviewedArtworkListViewModel
                                 .fetchReviewedArtworkListCellList(for: userId, before: lastArtworkId)
                         }
-                    case .isLoading(let last):
-                        print("last")
+                    case .isLoading:
+                        break
                     default:
                         return
                 }

--- a/Gom4ziz/Source/Presenter/Main/ReviewedArtworkList/MainViewSkeletonUI.swift
+++ b/Gom4ziz/Source/Presenter/Main/ReviewedArtworkList/MainViewSkeletonUI.swift
@@ -18,6 +18,7 @@ final class MainViewSkeletonUI: BaseAutoLayoutUIView {
 
     init() {
         super.init(frame: .zero)
+        backgroundColor = .white
     }
 
     required init?(coder: NSCoder) {

--- a/Gom4ziz/Source/Presenter/Main/ReviewedArtworkList/MainViewSkeletonUI.swift
+++ b/Gom4ziz/Source/Presenter/Main/ReviewedArtworkList/MainViewSkeletonUI.swift
@@ -1,0 +1,195 @@
+//
+//  MainViewSkeletonUI.swift
+//  Gom4ziz
+//
+//  Created by JongHo Park on 2022/12/04.
+//
+
+import UIKit
+
+final class MainViewSkeletonUI: BaseAutoLayoutUIView {
+
+    private let bigRectangle: UIView = .init()
+    private let titleRectangle: UIView = .init()
+    private let divider: UIView = .init()
+    private let firstCell: CellSkeletonView = .init()
+    private let secondCell: CellSkeletonView = .init()
+    private let thirdCell: CellSkeletonView = .init()
+
+    init() {
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+}
+
+// MARK: - 프로토콜 설정부분
+extension MainViewSkeletonUI {
+
+    func addSubviews() {
+        addSubviews(
+            bigRectangle,
+            titleRectangle,
+            divider,
+            firstCell,
+            secondCell,
+            thirdCell
+        )
+    }
+
+    func setUpConstraints() {
+        bigRectangle.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            bigRectangle.leftAnchor.constraint(equalTo: leftAnchor),
+            bigRectangle.rightAnchor.constraint(equalTo: rightAnchor),
+            bigRectangle.topAnchor.constraint(equalTo: topAnchor),
+            bigRectangle.heightAnchor.constraint(equalToConstant: 400)
+        ])
+
+        titleRectangle.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            titleRectangle.leftAnchor.constraint(equalTo: leftAnchor, constant: 16),
+            titleRectangle.topAnchor.constraint(equalTo: bigRectangle.bottomAnchor, constant: 28),
+            titleRectangle.widthAnchor.constraint(equalToConstant: 75),
+            titleRectangle.heightAnchor.constraint(equalToConstant: 15)
+        ])
+
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            divider.leftAnchor.constraint(equalTo: leftAnchor, constant: 16),
+            divider.rightAnchor.constraint(equalTo: rightAnchor, constant: -16),
+            divider.topAnchor.constraint(equalTo: titleRectangle.bottomAnchor, constant: 9.5),
+            divider.heightAnchor.constraint(equalToConstant: 2)
+        ])
+
+        firstCell.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            firstCell.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: 20),
+            firstCell.leftAnchor.constraint(equalTo: divider.leftAnchor),
+            firstCell.rightAnchor.constraint(equalTo: divider.rightAnchor)
+        ])
+
+        secondCell.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            secondCell.topAnchor.constraint(equalTo: firstCell.bottomAnchor, constant: 20),
+            secondCell.leftAnchor.constraint(equalTo: divider.leftAnchor),
+            secondCell.rightAnchor.constraint(equalTo: divider.rightAnchor)
+        ])
+
+        thirdCell.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            thirdCell.leftAnchor.constraint(equalTo: divider.leftAnchor),
+            thirdCell.rightAnchor.constraint(equalTo: divider.rightAnchor),
+            thirdCell.topAnchor.constraint(equalTo: secondCell.bottomAnchor, constant: 20)
+        ])
+    }
+
+    func setUpUI() {
+        bigRectangle.backgroundColor = .skeleton
+        titleRectangle.backgroundColor = .skeleton
+        titleRectangle.layer.cornerRadius = 4
+        titleRectangle.layer.masksToBounds = true
+        divider.backgroundColor = .skeleton
+    }
+
+    override func removeFromSuperview() {
+        UIView.animate(withDuration: 0.5, delay: 0) {
+            self.layer.opacity = 0
+        } completion: { _ in
+            super.removeFromSuperview()
+        }
+    }
+}
+
+final class CellSkeletonView: BaseAutoLayoutUIView {
+
+    private let bottomDivider: UIView = UIView()
+    private let titleRectangle: UIView = UIView()
+    private let descriptionRectangle: UIView = UIView()
+    private let secondRectangle: UIView = UIView()
+    private let imageRectangle: UIView = UIView()
+
+    init() {
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    func addSubviews() {
+        addSubviews(
+            bottomDivider,
+            titleRectangle,
+            descriptionRectangle,
+            secondRectangle,
+            imageRectangle
+        )
+    }
+
+    func setUpConstraints() {
+        titleRectangle.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            titleRectangle.widthAnchor.constraint(equalToConstant: 92),
+            titleRectangle.leftAnchor.constraint(equalTo: leftAnchor),
+            titleRectangle.heightAnchor.constraint(equalToConstant: 14),
+            titleRectangle.topAnchor.constraint(equalTo: topAnchor, constant: 12)
+        ])
+
+        imageRectangle.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            imageRectangle.rightAnchor.constraint(equalTo: rightAnchor),
+            imageRectangle.widthAnchor.constraint(equalToConstant: 90),
+            imageRectangle.topAnchor.constraint(equalTo: topAnchor),
+            imageRectangle.heightAnchor.constraint(equalToConstant: 120)
+        ])
+        descriptionRectangle.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            descriptionRectangle.leftAnchor.constraint(equalTo: titleRectangle.leftAnchor),
+            descriptionRectangle.heightAnchor.constraint(equalToConstant: 16),
+            descriptionRectangle.rightAnchor.constraint(equalTo: imageRectangle.leftAnchor, constant: -25),
+            descriptionRectangle.topAnchor.constraint(equalTo: titleRectangle.bottomAnchor, constant: 10)
+        ])
+
+        secondRectangle.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            secondRectangle.leftAnchor.constraint(equalTo: titleRectangle.leftAnchor),
+            secondRectangle.topAnchor.constraint(equalTo: descriptionRectangle.bottomAnchor, constant: 8),
+            secondRectangle.heightAnchor.constraint(equalToConstant: 16),
+            secondRectangle.rightAnchor.constraint(equalTo: imageRectangle.leftAnchor, constant: -32)
+        ])
+
+        bottomDivider.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            bottomDivider.leftAnchor.constraint(equalTo: leftAnchor),
+            bottomDivider.rightAnchor.constraint(equalTo: rightAnchor),
+            bottomDivider.topAnchor.constraint(equalTo: imageRectangle.bottomAnchor, constant: 20),
+            bottomDivider.heightAnchor.constraint(equalToConstant: 1),
+            bottomDivider.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+    func setUpUI() {
+        titleRectangle.backgroundColor = .skeleton
+        titleRectangle.layer.cornerRadius = 4
+        imageRectangle.backgroundColor = .skeleton
+        imageRectangle.layer.cornerRadius = 8
+        descriptionRectangle.backgroundColor = .skeleton
+        descriptionRectangle.layer.cornerRadius = 4
+        secondRectangle.backgroundColor = .skeleton
+        secondRectangle.layer.cornerRadius = 4
+        bottomDivider.backgroundColor = .skeleton
+    }
+}
+
+#if DEBUG
+import SwiftUI
+struct MainViewSkeletonUIPreviews: PreviewProvider {
+    static var previews: some View {
+        MainViewSkeletonUI().toPreview()
+    }
+}
+#endif

--- a/Gom4ziz/Source/System/SceneDelegate.swift
+++ b/Gom4ziz/Source/System/SceneDelegate.swift
@@ -23,7 +23,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         window?.makeKeyAndVisible()
         // 테스트를 위해서 루트 뷰컨트롤러를 변경할 수 있습니다.
-        testZoomableAsyncImageView()
+        testReviewedArtworkListView()
         changeStatusBarBgColor(bgColor: .white)
     }
     


### PR DESCRIPTION
## Close Issues
🔒 Close #173 

## 작업 내용 (Content)
- 메인뷰 로딩 스켈레톤 UI를 구현함
- 메인뷰에서 데이터가 로딩 상태일 시, 스켈레톤 UI를 subView로 추가함 (화면 꽉차게)
- 메인뷰에서 데이터의 로딩 이벤트가 종료될 경우 스켈레톤 UI를 지움 (fade out 효과와 함께)

## Review points
- removeFromSuperView를 override해서, fade out 애니메이션을 구현했습니다.

## 기타 사항 (Etc)

## 관련 사진 gif 및 (Optional)
![Simulator Screen Recording - iPhone 13 - 2022-12-04 at 17 28 03](https://user-images.githubusercontent.com/57793298/205481281-e458b96e-af60-48c0-83da-980eb273a367.gif)

## References (Optional)
- 참고한 사이트나 정리한 wiki 링크를 넣어주세요
- [링크이름](링크)
