### PR TITLE
[Feature] #170:  유저가 작성한 작품에 대한 리뷰가 없을 때 보여주는 UI 구현했습니다.

### DIFF
--- a/Gom4ziz/Source/Constants/ErrorViewMessage.swift
+++ b/Gom4ziz/Source/Constants/ErrorViewMessage.swift
@@ -7,8 +7,40 @@
 
 import Foundation
 
-enum ErrorViewMessage: String {
-    case artwork = "작품을 불러오는데 실패했습니다."
-    case tiramisul = "티라미술을 불러오는데 실패했습니다."
-    case reviewedArtwork = "감상 기록을 불러오지 못했습니다."
+enum ErrorType: String {
+    case artwork = "작품"
+    case question = "작가의 질문"
+    case artworkDescription = "작품 설명"
+}
+
+enum ErrorViewMessage {
+    case loadFailed(type: ErrorType)
+    case noReview
+    case networkError(type: ErrorType)
+}
+
+extension ErrorViewMessage {
+    
+    var header: String {
+        switch self {
+        case .loadFailed(let type):
+            return "\(type.rawValue)을 불러오지 못했습니다."
+        case .noReview:
+            return "아직 감상한 작품이 없습니다."
+        case .networkError(let type):
+            return "\(type.rawValue)을 불러오지 못했습니다."
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .noReview:
+            return "작가의 질문에 답해보고 작품을 감상해보세요"
+        case .networkError:
+            return "네트워크 연결을 확인하고 다시 시도해주세요."
+        default:
+            return "아래 버튼을 탭해서 다시 불러와 보세요."
+        }
+    }
+    
 }

--- a/Gom4ziz/Source/Data/Repository/FirebaseArtworkRepository.swift
+++ b/Gom4ziz/Source/Data/Repository/FirebaseArtworkRepository.swift
@@ -22,6 +22,7 @@ final class FirebaseArtworkRepository {
 
 // MARK: - ArtworkRepository protocol extension
 extension FirebaseArtworkRepository: ArtworkRepository {
+    
     func requestArtwork(of artworkId: Int) -> Observable<Artwork> {
         getArtworkRef(of: artworkId)
             .rx
@@ -33,10 +34,12 @@ extension FirebaseArtworkRepository: ArtworkRepository {
             .rx
             .decodable(as: [Artwork].self)
     }
+    
 }
 
 // MARK: - private extension
 extension FirebaseArtworkRepository {
+    
     func getArtworkRef(of artworkId: Int) -> DocumentReference {
         db
             .collection(CollectionName.artwork)
@@ -48,4 +51,5 @@ extension FirebaseArtworkRepository {
             .collection(CollectionName.artwork)
             .whereField("id", isLessThanOrEqualTo: artworkId)
     }
+    
 }

--- a/Gom4ziz/Source/Data/Repository/FirebaseArtworkReviewRepository.swift
+++ b/Gom4ziz/Source/Data/Repository/FirebaseArtworkReviewRepository.swift
@@ -100,4 +100,5 @@ extension FirebaseArtworkReviewRepository {
             .collection(CollectionName.user)
             .document(uid)
     }
+    
 }

--- a/Gom4ziz/Source/Data/Repository/FirebaseQuestionAnswerRepository.swift
+++ b/Gom4ziz/Source/Data/Repository/FirebaseQuestionAnswerRepository.swift
@@ -32,10 +32,12 @@ extension FirebaseQuestionAnswerRepository: QuestionAnswerRepository {
 
         return Observable.zip(observables)
     }
+    
 }
 
 // MARK: - private extension
 extension FirebaseQuestionAnswerRepository {
+    
     private func getQuestionAnswerRef(for userId: String, before artworkId: Int) -> DocumentReference {
         db
             .collection(CollectionName.artwork)
@@ -43,5 +45,6 @@ extension FirebaseQuestionAnswerRepository {
             .collection(CollectionName.questionAnswer)
             .document(String(userId))
     }
+    
 }
 

--- a/Gom4ziz/Source/Data/Repository/FirebaseUserRepository.swift
+++ b/Gom4ziz/Source/Data/Repository/FirebaseUserRepository.swift
@@ -21,6 +21,7 @@ final class FirebaseUserRepository {
 
 // MARK: - UserRepository protocol extension
 extension FirebaseUserRepository: UserRepository {
+    
     func addUser(for userId: String) -> Single<User> {
         let user = User(id: userId,
                         lastArtworkId: 0,
@@ -30,17 +31,21 @@ extension FirebaseUserRepository: UserRepository {
             .setData(user)
             .map { user }
     }
+    
     func fetchUser(for userId: String) -> Observable<User> {
         return getUserRef(of: userId)
             .rx
             .decodable(as: User.self)
     }
+    
 }
 
 // MARK: - private extension
 private extension FirebaseUserRepository {
+    
     private func getUserRef(of userId: String) -> DocumentReference {
         db.collection(CollectionName.user)
             .document(userId)
     }
+    
 }

--- a/Gom4ziz/Source/Extension/UIViewController+Loadble.swift
+++ b/Gom4ziz/Source/Extension/UIViewController+Loadble.swift
@@ -9,8 +9,8 @@ import UIKit
 
 extension UIViewController {
     
-    func showErrorView(_ message: ErrorViewMessage, _ isShowLogo: Bool, onRetryButtonTapped: @escaping () -> Void = { }) {
-        let errorView: ErrorView = .init(message: message, isShowLogo: isShowLogo, onRetryButtonTapped: onRetryButtonTapped)
+    func showErrorView(_ message: ErrorViewMessage, _ isShowLogo: Bool, onButtonTapped: @escaping () -> Void = { }) {
+        let errorView: ErrorView = .init(message: message, isShowLogo: isShowLogo, onButtonTapped: onButtonTapped)
         errorView.tag = ViewTag.errorView.rawValue
         self.view.addSubview(errorView)
         errorView.translatesAutoresizingMaskIntoConstraints = false

--- a/Gom4ziz/Source/Presenter/Component/ErrorView.swift
+++ b/Gom4ziz/Source/Presenter/Component/ErrorView.swift
@@ -28,15 +28,15 @@ final class ErrorView: BaseAutoLayoutUIView {
     
     private lazy var errorMessageLabel: UILabel = {
         let label = UILabel()
-        label.text = message.rawValue
+        label.text = message.header
         label.textStyle(.Title, .blackFont)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
-    private let captionLabel: UILabel = {
+    private lazy var captionLabel: UILabel = {
         let label = UILabel()
-        label.text = "아래 버튼을 탭해서 다시 불러와 보세요."
+        label.text = message.description
         label.textStyle(.NavigationButton, .gray3)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -51,6 +51,16 @@ final class ErrorView: BaseAutoLayoutUIView {
         stackView.spacing = Size.messageStackViewSpcing
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
+    }()
+    
+    lazy var appriciateArtworkButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.setTitle("첫 작품 감상하러가기 →", for: .normal)
+        button.titleLabel?.font = .boldSystemFont(ofSize: 12)
+        button.backgroundColor = .gray4
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(appriciateArtworkButtonTapped), for: .touchUpInside)
+        return button
     }()
     
     lazy var retryButton: UIButton = {
@@ -69,7 +79,6 @@ final class ErrorView: BaseAutoLayoutUIView {
             stackView.addArrangedSubview(logoImageView)
         }
         stackView.addArrangedSubview(messageStackView)
-        stackView.addArrangedSubview(retryButton)
         stackView.distribution = .fill
         stackView.alignment = .center
         stackView.axis = .vertical
@@ -78,12 +87,12 @@ final class ErrorView: BaseAutoLayoutUIView {
         return stackView
     }()
     
-    private let onRetryButtonTapped: () -> Void
+    private let onButtonTapped: () -> Void
     
-    init(message: ErrorViewMessage, isShowLogo: Bool = true, onRetryButtonTapped: @escaping () -> Void) {
+    init(message: ErrorViewMessage, isShowLogo: Bool = true, onButtonTapped: @escaping () -> Void) {
         self.message = message
         self.isShowLogo = isShowLogo
-        self.onRetryButtonTapped = onRetryButtonTapped
+        self.onButtonTapped = onButtonTapped
         super.init(frame: .zero)
     }
     
@@ -102,13 +111,31 @@ extension ErrorView {
     }
     
     func setUpConstraints() {
+        setErrorViewConstraints()
+        setButtonConstraints()
+    }
+    
+    func setErrorViewConstraints() {
         NSLayoutConstraint.activate([
             errorStackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            errorStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            
-            retryButton.widthAnchor.constraint(equalToConstant: Size.buttonWidth),
-            retryButton.heightAnchor.constraint(equalToConstant: Size.buttonHeight)
+            errorStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor)
         ])
+    }
+    
+    func setButtonConstraints() {
+        if case .noReview = message {
+            errorStackView.addArrangedSubview(appriciateArtworkButton)
+            NSLayoutConstraint.activate([
+                appriciateArtworkButton.widthAnchor.constraint(equalToConstant: Size.buttonWidth),
+                appriciateArtworkButton.heightAnchor.constraint(equalToConstant: Size.buttonHeight)
+            ])
+        } else {
+            errorStackView.addArrangedSubview(retryButton)
+            NSLayoutConstraint.activate([
+                retryButton.widthAnchor.constraint(equalToConstant: Size.buttonWidth),
+                retryButton.heightAnchor.constraint(equalToConstant: Size.buttonHeight)
+            ])
+        }
     }
     
     func setUpUI() {
@@ -122,7 +149,12 @@ extension ErrorView {
 private extension ErrorView {
     
     @objc func retryButtonTapped() {
-        onRetryButtonTapped()
+        onButtonTapped()
+        self.removeFromSuperview()
+    }
+    
+    @objc func appriciateArtworkButtonTapped() {
+        onButtonTapped()
         self.removeFromSuperview()
     }
     
@@ -132,9 +164,9 @@ private extension ErrorView {
 import SwiftUI
 struct ErrorViewPreview: PreviewProvider {
     static var previews: some View {
-        ErrorView(message: .tiramisul, isShowLogo: false) {
+        ErrorView(message: .noReview, isShowLogo: false, onButtonTapped: {
             
-        }
+        })
             .toPreview()
     }
 }

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedView.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedView.swift
@@ -34,7 +34,11 @@ final class MyFeedView: BaseAutoLayoutUIView {
         return label
     }()
     
-    private lazy var questionAnswerSectionTitleView = SectionTitleView(title: "나의 생각")
+    private lazy var questionAnswerSectionTitleView = {
+        let titleView = SectionTitleView(title: "나의 생각")
+        titleView.translatesAutoresizingMaskIntoConstraints = false
+        return titleView
+    }()
     
     private lazy var questionAnswerLabel: UILabel = {
         let label = UILabel()
@@ -104,9 +108,18 @@ final class MyFeedView: BaseAutoLayoutUIView {
     
     // 작품 소개
     
-    private lazy var artworkDesciptionSectionTitleView: SectionTitleView = .init(title: "작품 소개")
+    private lazy var artworkDesciptionSectionTitleView: SectionTitleView = {
+        let titleView = SectionTitleView(title: "작품 소개")
+        titleView.translatesAutoresizingMaskIntoConstraints = false
+        return titleView
+    }()
     
-    lazy var highlightTextView: HighlightedTextView = HighlightedTextView(text: " ", highlights: [], isEditable: false, isExpandable: false)
+    lazy var highlightTextView: HighlightedTextView = {
+        let textView = HighlightedTextView(text: " ", highlights: [], isEditable: false, isExpandable: false)
+        textView.textView.textStyle(.Body1, .blackFont)
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        return textView
+    }()
     
     private lazy var artworkDescriptionStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [artworkDesciptionSectionTitleView,
@@ -121,10 +134,15 @@ final class MyFeedView: BaseAutoLayoutUIView {
     
     // 나의 감상
     
-    private lazy var reviewSectionTitleView: SectionTitleView = .init(title: "나의 감상")
+    private lazy var reviewSectionTitleView: SectionTitleView = {
+        let titleView = SectionTitleView(title: "나의 감상")
+        titleView.translatesAutoresizingMaskIntoConstraints = false
+        return titleView
+    }()
     
     lazy var reviewLabel: UILabel = {
         let label = UILabel()
+        label.text = ""
         label.numberOfLines = 0
         label.textStyle(.Body1, .blackFont)
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewController.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewController.swift
@@ -93,7 +93,7 @@ private extension MyFeedViewController {
                     self?.hideLottieLoadingView()
                 case .failed:
                     self?.hideLottieLoadingView()
-                    self?.showErrorView(.tiramisul, false) {
+                    self?.showErrorView(.loadFailed(type: .artwork), false) {
                         self?.viewModel.fetchMyFeed()
                     }
                 }

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewModel.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewModel.swift
@@ -78,7 +78,6 @@ final class MyFeedViewModel {
         let myAnswer = myAnswer.value
         let review = review.value
         let highlights = myFeedViewModelRelay.value.value?.highlights ?? []
-        print(myAnswer, review, highlights)
         addArtworkReviewUseCase.addArtworkReview(maker: userId,
                                                  of: artwork.id,
                                                  review: review,

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewModel.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewModel.swift
@@ -29,23 +29,36 @@ final class MyFeedViewModel {
     private let fetchArtworkReviewUseCase: FetchArtworkReviewUseCase
     private let fetchArtworkDescriptionUseCase: FetchArtworkDescriptionUseCase
     private let fetchHighlightUseCase: FetchHighlightUseCase
-    let myFeedViewModelRelay: BehaviorRelay<Loadable<MyFeedViewModelDTO>> = .init(value: .notRequested)
+    private let addArtworkReviewUseCase: AddArtworkReviewUsecase
     
+    let myFeedViewModelRelay: BehaviorRelay<Loadable<MyFeedViewModelDTO>> = .init(value: .notRequested)
+    let updateEvent: BehaviorRelay<Loadable<Void>> = .init(value: .notRequested)
+    let myAnswer: BehaviorRelay<String> = .init(value: "")
+    let review: BehaviorRelay<String> = .init(value: "")
+    
+    private let userId: String
+    let artwork: Artwork
     private let disposeBag: DisposeBag = .init()
     
-    init(fetchArtworkReviewUseCase: FetchArtworkReviewUseCase,
+    init(userId: String,
+         of artwork: Artwork,
+         fetchArtworkReviewUseCase: FetchArtworkReviewUseCase,
          fetchArtworkDescriptionUseCase: FetchArtworkDescriptionUseCase,
-         fetchHighlightUseCase: FetchHighlightUseCase) {
+         fetchHighlightUseCase: FetchHighlightUseCase,
+         addArtworkReviewUseCase: AddArtworkReviewUsecase) {
+        self.userId = userId
+        self.artwork = artwork
         self.fetchArtworkReviewUseCase = fetchArtworkReviewUseCase
         self.fetchArtworkDescriptionUseCase = fetchArtworkDescriptionUseCase
         self.fetchHighlightUseCase = fetchHighlightUseCase
+        self.addArtworkReviewUseCase = addArtworkReviewUseCase
     }
     
-    func fetchMyFeed(artworkId: Int, userId: String) {
+    func fetchMyFeed() {
         myFeedViewModelRelay.accept(.isLoading(last: nil))
-        Observable.zip(fetchArtworkDescription(of: artworkId),
-                       fetchHighlight(of: artworkId, userId),
-                       fetchArtworkReview(of: artworkId, userId))
+        Observable.zip(fetchArtworkDescription(),
+                       fetchHighlight(),
+                       fetchArtworkReview())
         .map { (description: ArtworkDescription, highlights: [Highlight], review: ArtworkReview) in
             MyFeedViewModelDTO(artworkDescription: description,
                                   highlights: highlights,
@@ -53,23 +66,42 @@ final class MyFeedViewModel {
         }
         .subscribe { [weak self] in
             self?.myFeedViewModelRelay.accept(.loaded($0))
+            self?.review.accept($0.artworkReview)
         } onError: { [weak self] in
             self?.myFeedViewModelRelay.accept(.failed($0))
         }
         .disposed(by: disposeBag)
-
     }
     
-    private func fetchArtworkDescription(of artworkId: Int) -> Observable<ArtworkDescription> {
-        fetchArtworkDescriptionUseCase.fetchArtworkDescription(of: artworkId)
+    func updateArtworkReview() {
+        updateEvent.accept(.isLoading(last: nil))
+        let myAnswer = myAnswer.value
+        let review = review.value
+        let highlights = myFeedViewModelRelay.value.value?.highlights ?? []
+        print(myAnswer, review, highlights)
+        addArtworkReviewUseCase.addArtworkReview(maker: userId,
+                                                 of: artwork.id,
+                                                 review: review,
+                                                 answer: myAnswer,
+                                                 highlights: highlights)
+        .subscribe(onSuccess: { [weak self] in
+            self?.updateEvent.accept(.loaded(()))
+        }, onFailure: { [weak self] in
+            self?.updateEvent.accept(.failed($0))
+        })
+        .disposed(by: disposeBag)
     }
     
-    private func fetchHighlight(of artworkId: Int, _ userId: String) -> Observable<[Highlight]> {
-        fetchHighlightUseCase.fetchHighlight(of: artworkId, userId)
+    private func fetchArtworkDescription() -> Observable<ArtworkDescription> {
+        fetchArtworkDescriptionUseCase.fetchArtworkDescription(of: artwork.id)
     }
     
-    private func fetchArtworkReview(of artworkId: Int, _ userId: String) -> Observable<ArtworkReview> {
-        fetchArtworkReviewUseCase.fetchArtwokReview(of: artworkId, userId)
+    private func fetchHighlight() -> Observable<[Highlight]> {
+        fetchHighlightUseCase.fetchHighlight(of: artwork.id, userId)
+    }
+    
+    private func fetchArtworkReview() -> Observable<ArtworkReview> {
+        fetchArtworkReviewUseCase.fetchArtwokReview(of: artwork.id, userId)
     }
     
 }

--- a/Gom4ziz/Source/Presenter/MyFeed/UpdateReview/UpdateReviewView.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/UpdateReview/UpdateReviewView.swift
@@ -1,0 +1,107 @@
+//
+//  UpdateReviewView.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/12/02.
+//
+
+import UIKit
+
+final class UpdateReviewView: BaseAutoLayoutUIView {
+    
+    private let question: String
+    private let myAnswer: String
+    private let myReview: String
+    
+    private lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+    
+    private lazy var questionLabel: UILabel = {
+        let label = UILabel()
+        label.text = question
+        label.numberOfLines = 0
+        label.textStyle(.Display2, .blackFont)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let myAnswerSectionTitleView = SectionTitleView(title: "나의 생각")
+    lazy var myAnswerInputTextView = PlaceholderTextView(text: myAnswer)
+    
+    private let myReviewSectionTitleView = SectionTitleView(title: "나의 감상")
+    lazy var myReviewInputTextView = PlaceholderTextView(text: myReview)
+    
+    init(question: String, myAnswer: String, myReview: String) {
+        self.question = question
+        self.myAnswer = myAnswer
+        self.myReview = myReview
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+extension UpdateReviewView {
+    
+    func addSubviews() {
+        self.addSubview(questionLabel)
+        self.addSubview(myAnswerSectionTitleView)
+        self.addSubview(myAnswerInputTextView)
+        self.addSubview(myReviewSectionTitleView)
+        self.addSubview(myReviewInputTextView)
+    }
+    
+    func setUpConstraints() {
+        myAnswerSectionTitleView.translatesAutoresizingMaskIntoConstraints = false
+        myAnswerInputTextView.translatesAutoresizingMaskIntoConstraints = false
+        myReviewSectionTitleView.translatesAutoresizingMaskIntoConstraints = false
+        myReviewInputTextView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            questionLabel.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor),
+            questionLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            questionLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
+            
+            myAnswerSectionTitleView.topAnchor.constraint(equalTo: questionLabel.bottomAnchor, constant: 40),
+            myAnswerSectionTitleView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            myAnswerSectionTitleView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
+            
+            myAnswerInputTextView.topAnchor.constraint(equalTo: myAnswerSectionTitleView.bottomAnchor, constant: 20),
+            myAnswerInputTextView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            myAnswerInputTextView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
+            myAnswerInputTextView.heightAnchor.constraint(equalToConstant: 240),
+            
+            myReviewSectionTitleView.topAnchor.constraint(equalTo: myAnswerInputTextView.bottomAnchor, constant: 40),
+            myReviewSectionTitleView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            myReviewSectionTitleView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
+            
+            myReviewInputTextView.topAnchor.constraint(equalTo: myReviewSectionTitleView.bottomAnchor, constant: 20),
+            myReviewInputTextView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            myReviewInputTextView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
+            myReviewInputTextView.heightAnchor.constraint(equalToConstant: 240),
+            myReviewInputTextView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -16)
+        ])
+    }
+    
+    func setUpUI() {
+        self.backgroundColor = .white
+    }
+    
+}
+
+#if DEBUG
+import SwiftUI
+
+struct UpdateReviewViewPreview: PreviewProvider {
+    static var previews: some View {
+        UpdateReviewView(question: Artwork.mockData.question, myAnswer: QuestionAnswer.mockData.questionAnswer, myReview: ArtworkReview.mockData.review)
+            .toPreview()
+    }
+}
+#endif

--- a/Gom4ziz/Source/Presenter/MyFeed/UpdateReview/UpdateReviewViewController.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/UpdateReview/UpdateReviewViewController.swift
@@ -1,0 +1,102 @@
+//
+//  UpdateReviewViewController.swift
+//  Gom4ziz
+//
+//  Created by 정재윤 on 2022/12/02.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+final class UpdateReviewViewController: UIViewController {
+    
+    private lazy var updateReviewView: UpdateReviewView = .init(question: viewModel.artwork.question, myAnswer: viewModel.myAnswer.value, myReview: viewModel.review.value)
+
+    private lazy var cancelButton: UIBarButtonItem = .init(title: "취소", style: .plain, target: self, action: #selector(cancelButtonTapped))
+    private lazy var completeButton: UIBarButtonItem = .init(title: "완료", style: .plain, target: self, action: #selector(completeButtonTapped))
+    
+    let viewModel: MyFeedViewModel
+    private let disposeBag: DisposeBag = .init()
+    
+    init(_ viewModel: MyFeedViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func loadView() {
+        self.view = updateReviewView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUpNavigationBar()
+        setObserver()
+    }
+    
+}
+
+extension UpdateReviewViewController {
+    
+    func setUpNavigationBar() {
+        navigationItem.title = "편집"
+        navigationItem.leftBarButtonItem = cancelButton
+        navigationItem.rightBarButtonItem = completeButton
+        navigationController?.navigationBar.tintColor = .black
+    }
+    
+}
+
+extension UpdateReviewViewController {
+    
+    @objc func cancelButtonTapped() {
+        dismiss(animated: true)
+    }
+    
+    @objc func completeButtonTapped() {
+        viewModel.updateArtworkReview()
+        dismiss(animated: true)
+    }
+    
+}
+
+extension UpdateReviewViewController {
+    
+    func setObserver() {
+        viewModel.updateEvent
+            .asDriver()
+            .drive(onNext: { [weak self] in
+                switch $0 {
+                case .notRequested:
+                    break
+                case .isLoading:
+                    self?.showLottieLoadingView()
+                case .loaded:
+                    self?.hideLottieLoadingView()
+                case .failed:
+                    self?.hideLottieLoadingView()
+                    self?.showErrorAlert(title: "감상문을 편집하는데 실패했습니다.",
+                                         suggestion: "작성한 감상문이 편집되지 않았습니다. 다시 시도하여 감상문을 편집해주세요.") { [unowned self] in
+                        self?.viewModel.updateArtworkReview()
+                    }
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel.review
+            .asDriver()
+            .drive(updateReviewView.myReviewInputTextView.rx.text)
+            .disposed(by: disposeBag)
+        
+        viewModel.myAnswer
+            .asDriver()
+            .drive(updateReviewView.myAnswerInputTextView.rx.text)
+            .disposed(by: disposeBag)
+    }
+    
+}

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionAnswerViewController.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionAnswerViewController.swift
@@ -74,7 +74,7 @@ private extension QuestionAnswerViewController {
                     self.focusOnTextView()
                 case .failed:
                     self.questionAnswerView.hideSkeletonUI()
-                    self.showErrorView(.artwork, true) {
+                    self.showErrorView(.loadFailed(type: .artwork), true) {
                         self.viewModel.fetchArtworkDescription()
                     }
                 default: break


### PR DESCRIPTION
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.
🔒 Close #170
🔒 Close #177

## 작업 내용 (Content)
- ReviewedArtworkList가 emty일 때, 사용자에게 아직 작성한 작품이 없다는 것을 명시하는 UI 구현했습니다.
이 과정에서 기존의 ErrorView를 조금 변경했고, 디자인 시안에서도 ErrorView의 종류가 다양해져서 ErrorMessage를 수정했습니다.
<img width="657" alt="Screenshot 2022-12-05 at 14 21 42" src="https://user-images.githubusercontent.com/59136391/205555646-2cfbe9d4-3ae5-4c7e-a333-64e7483a7e58.png">

```swift
enum ErrorViewMessage {
    case loadFailed(type: ErrorType)
    case noReview
    case networkError(type: ErrorType)
}
```
디자인 시안에 따라 에러의 종류를 3개로 나눴습니다.

ErrorMessage가 `.noReview`일 때는 탭하여 다시 시도 버튼이 아니기 때문에 이를 구분할 수 있도록 처리했습니다.

- 유저가 감상 기록을 편집할 수 있도록 했습니다.
새로 update 유즈케이스를 만든 것은 아니고, 기존에 호종이가 만든 add 유즈케이스를 활용했습니다.


## Review points
- 리뷰어가 중점적으로 리뷰해줬으면 하는 포인트

## 기타 사항 (Etc)
- 작업하면서 고민이 되었던 부분이나 질문 사항 등

## 관련 사진 gif 및 (Optional)

## References (Optional)
- 참고한 사이트나 정리한 wiki 링크를 넣어주세요
- [링크이름](링크)
