### PR TITLE
리허설 때 나온 피드백 중 대부분을 반영하였습니다.

### DIFF
--- a/Gom4ziz/Source/Data/Repository/FirebaseArtworkDescriptionRepository.swift
+++ b/Gom4ziz/Source/Data/Repository/FirebaseArtworkDescriptionRepository.swift
@@ -19,15 +19,19 @@ final class FirebaseArtworkDescriptionRepository {
     
     static let shared: FirebaseArtworkDescriptionRepository = .init()
     private let db: Firestore = Firestore.firestore()
-    
+    private var cache: Set<Int> = []
+
 }
 
 extension FirebaseArtworkDescriptionRepository: ArtworkDescriptionRepository {
     
     func fetchArtworkDescription(of artworkId: Int) -> Observable<ArtworkDescription> {
-        getArtworkDescripionRef(of: artworkId)
+        let source: FirestoreSource = cache.contains(artworkId) ? .cache: .server
+
+        return getArtworkDescripionRef(of: artworkId)
             .rx
-            .decodable(as: ArtworkDescription.self)
+            .decodable(as: ArtworkDescription.self, source: source)
+            .do(onNext: { _ in self.cache.insert(artworkId) })
     }
     
 }

--- a/Gom4ziz/Source/Domain/Model/MockData.swift
+++ b/Gom4ziz/Source/Domain/Model/MockData.swift
@@ -19,7 +19,7 @@ extension User {
 extension Artwork {
     static var mockData: Artwork {
         Artwork(id: 1,
-                imageUrl: "https://firebasestorage.googleapis.com/v0/b/gom4ziz.appspot.com/o/Rectangle393.png?alt=media&token=ae36097f-221b-4722-a145-068f1aaeca51",
+                imageUrl: "https://firebasestorage.googleapis.com/v0/b/gom4ziz.appspot.com/o/AHoliday.png?alt=media&token=e597eeec-127c-4bbc-a6f0-ee1694746288",
                 question: "현대 사회에서 동물과 인류는 어떻게 공존과 공생을 할 수 있을까요?",
                 title: "작은 방주",
                 artist: "최우람")

--- a/Gom4ziz/Source/Presenter/Component/AsyncImageView.swift
+++ b/Gom4ziz/Source/Presenter/Component/AsyncImageView.swift
@@ -17,14 +17,17 @@ final class AsyncImageView: UIImageView {
     private let filterOptions: [ImageFilterOption]
     private var previousDisposable: Disposable?
     private let asyncImageManager: AsyncImageManager = .shared
+    private let sizeToAspectFit: Bool
 
     init(
         url string: String,
         progressView: UIView = UIActivityIndicatorView(style: .large),
         contentMode: ContentMode = .scaleAspectFill,
-        filterOptions: [ImageFilterOption] = []
+        filterOptions: [ImageFilterOption] = [],
+        sizeToAspectFit: Bool = false
     ) {
         self.url = string
+        self.sizeToAspectFit = sizeToAspectFit
         self.filterOptions = filterOptions
         self.progressView = progressView
         super.init(frame: .zero)
@@ -103,11 +106,25 @@ private extension AsyncImageView {
                 guard let self else { return }
                 self.removeProgressView()
                 self.image = image
+                self.setSizeToAspectFit()
             }, onFailure: { [weak self] error in
                 guard let self else { return }
                 self.removeProgressView()
                 self.addErrorIndicator(error)
             })
+    }
+
+    func setSizeToAspectFit() {
+        guard sizeToAspectFit, let image, image.size.height > 0 else {
+            return
+        }
+
+        let aspectRatio: CGFloat = image.size.height / image.size.width
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(lessThanOrEqualTo: widthAnchor, multiplier: aspectRatio),
+            heightAnchor.constraint(lessThanOrEqualToConstant: 350)
+        ])
     }
 
     func removeProgressView() {

--- a/Gom4ziz/Source/Presenter/Component/HighlightedTextView.swift
+++ b/Gom4ziz/Source/Presenter/Component/HighlightedTextView.swift
@@ -25,7 +25,7 @@ final class HighlightedTextView: BaseAutoLayoutUIView {
     private let highlightTextColor: UIColor
     let textView: UITextView = UITextView()
     private let addButton: UIButton = UIButton()
-    private let toggleButton: UILabel = UILabel()
+    private let toggleButton: PaddingLabel = PaddingLabel(.init(top: 8, left: 0, bottom: 4, right: 8))
     private let deleteButton: BubbleButton = BubbleButton(text: "삭제")
     private let isEditable: Bool
     var onHighlightsChanged: (([Highlight]) -> Void)?
@@ -91,8 +91,9 @@ extension HighlightedTextView {
             toggleButton.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
                 toggleButton.leadingAnchor.constraint(equalTo: textView.leadingAnchor),
-                toggleButton.topAnchor.constraint(equalTo: textView.bottomAnchor, constant: 4),
-                toggleButton.bottomAnchor.constraint(equalTo: bottomAnchor)
+                toggleButton.topAnchor.constraint(equalTo: textView.bottomAnchor),
+                toggleButton.bottomAnchor.constraint(equalTo: bottomAnchor),
+                toggleButton.heightAnchor.constraint(equalToConstant: 30)
             ])
         } else {
             NSLayoutConstraint.activate([textView.bottomAnchor.constraint(equalTo: bottomAnchor)])

--- a/Gom4ziz/Source/Presenter/Component/PaddingLabel.swift
+++ b/Gom4ziz/Source/Presenter/Component/PaddingLabel.swift
@@ -1,0 +1,33 @@
+//
+//  PaddingLabel.swift
+//  Gom4ziz
+//
+//  Created by JongHo Park on 2022/12/08.
+//
+
+import UIKit
+
+final class PaddingLabel: UILabel {
+
+    var padding: UIEdgeInsets
+
+    init(_ padding: UIEdgeInsets) {
+        self.padding = padding
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: padding))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        var contentSize = super.intrinsicContentSize
+        contentSize.height += padding.top + padding.bottom
+        contentSize.width += padding.left + padding.right
+        return contentSize
+    }
+}

--- a/Gom4ziz/Source/Presenter/Component/ZoomableAsyncImageView.swift
+++ b/Gom4ziz/Source/Presenter/Component/ZoomableAsyncImageView.swift
@@ -21,6 +21,7 @@ final class ZoomableAsyncImageView: UIScrollView {
     ) {
         asyncImageView = AsyncImageView(url: url, contentMode: contentMode, filterOptions: filterOptions)
         super.init(frame: .zero)
+        isScrollEnabled = false
         addSubview(asyncImageView)
         setUpUI()
         setUpDoubleTapGestureRecognizer()
@@ -64,6 +65,7 @@ extension ZoomableAsyncImageView {
 }
 
 extension ZoomableAsyncImageView: UIScrollViewDelegate {
+
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
         self.asyncImageView
     }
@@ -75,6 +77,16 @@ extension ZoomableAsyncImageView: UIScrollViewDelegate {
             zoomScale = minimumScale
         }
     }
+
+    func scrollViewDidZoom(_ scrollView: UIScrollView) {
+        if zoomScale > minimumScale && !isScrollEnabled {
+            isScrollEnabled.toggle()
+            return
+        } else if zoomScale == minimumScale && isScrollEnabled {
+            isScrollEnabled.toggle()
+        }
+    }
+
 }
 
 // MARK: - 더블탭 제스처

--- a/Gom4ziz/Source/Presenter/Component/ZoomableAsyncImageView.swift
+++ b/Gom4ziz/Source/Presenter/Component/ZoomableAsyncImageView.swift
@@ -11,6 +11,8 @@ final class ZoomableAsyncImageView: UIScrollView {
 
     private let asyncImageView: AsyncImageView
     private var isSizeDetermined: Bool = false
+    private let maximumScale: CGFloat = 10
+    private let minimumScale: CGFloat = 1
 
     init(
         url: String,
@@ -21,6 +23,7 @@ final class ZoomableAsyncImageView: UIScrollView {
         super.init(frame: .zero)
         addSubview(asyncImageView)
         setUpUI()
+        setUpDoubleTapGestureRecognizer()
         asyncImageView.frame = CGRect(x: 0, y: 0, width: 300, height: 300)
     }
 
@@ -31,10 +34,10 @@ final class ZoomableAsyncImageView: UIScrollView {
     private func setUpUI() {
         showsVerticalScrollIndicator = false
         showsHorizontalScrollIndicator = false
-        minimumZoomScale = 1
-        maximumZoomScale = 3
         alwaysBounceVertical = true
         alwaysBounceHorizontal = true
+        maximumZoomScale = maximumScale
+        minimumZoomScale = minimumScale
         delegate = self
     }
 
@@ -66,12 +69,31 @@ extension ZoomableAsyncImageView: UIScrollViewDelegate {
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if zoomScale > 3 {
-            zoomScale = 3
-        } else if zoomScale < 1 {
-            zoomScale = 1
+        if zoomScale > maximumScale {
+            zoomScale = maximumScale
+        } else if zoomScale < minimumScale {
+            zoomScale = minimumScale
         }
     }
+}
+
+// MARK: - 더블탭 제스처
+private extension ZoomableAsyncImageView {
+
+    func setUpDoubleTapGestureRecognizer() {
+        let doubleTap = UITapGestureRecognizer(target: self, action: #selector(doubleTapped))
+        doubleTap.numberOfTapsRequired = 2
+        addGestureRecognizer(doubleTap)
+    }
+
+    @objc func doubleTapped() {
+        if zoomScale < 1.5 {
+            setZoomScale(4, animated: true)
+            return
+        }
+        setZoomScale(minimumScale, animated: true)
+    }
+
 }
 
 #if DEBUG

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedView.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedView.swift
@@ -64,7 +64,9 @@ final class MyFeedView: BaseAutoLayoutUIView {
     
     lazy var artworkImageView: AsyncImageView = .init(
         url: artwork.imageUrl,
-        contentMode: .scaleAspectFill)
+        contentMode: .scaleAspectFit,
+        sizeToAspectFit: true
+    )
     
     private lazy var artworkTitleLabel: UILabel = {
         let label = UILabel()
@@ -230,6 +232,10 @@ extension MyFeedView {
             reviewStackView.rightAnchor.constraint(equalTo: myFeedStackView.rightAnchor, constant: -16),
             reviewStackView.bottomAnchor.constraint(equalTo: myFeedStackView.bottomAnchor)
         ])
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
     }
     
     func setUpUI() {

--- a/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewModel.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/MyFeedViewModel.swift
@@ -32,7 +32,7 @@ final class MyFeedViewModel {
     private let addArtworkReviewUseCase: AddArtworkReviewUsecase
     
     let myFeedViewModelRelay: BehaviorRelay<Loadable<MyFeedViewModelDTO>> = .init(value: .notRequested)
-    let updateEvent: BehaviorRelay<Loadable<Void>> = .init(value: .notRequested)
+    let updateEvent: PublishRelay<Loadable<Void>> = .init()
     let myAnswer: BehaviorRelay<String> = .init(value: "")
     let review: BehaviorRelay<String> = .init(value: "")
     

--- a/Gom4ziz/Source/Presenter/MyFeed/UpdateReview/UpdateReviewViewController.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/UpdateReview/UpdateReviewViewController.swift
@@ -64,7 +64,7 @@ extension UpdateReviewViewController {
     
     func setObserver() {
         viewModel.updateEvent
-            .asDriver()
+            .asDriver(onErrorJustReturn: .notRequested)
             .drive(onNext: { [weak self] in
                 switch $0 {
                 case .notRequested:
@@ -73,6 +73,7 @@ extension UpdateReviewViewController {
                     self?.showLottieLoadingView()
                 case .loaded:
                     self?.hideLottieLoadingView()
+                    self?.dismiss(animated: true)
                 case .failed:
                     self?.hideLottieLoadingView()
                     self?.showErrorAlert(title: "감상문을 편집하는데 실패했습니다.",
@@ -91,13 +92,11 @@ extension UpdateReviewViewController {
             .bind(to: updateReviewView.myAnswerInputTextView.rx.text)
             .disposed(by: disposeBag)
         
-        
         completeButton
             .rx
             .tap
             .subscribe(onNext: { [unowned self] in
                 self.viewModel.updateArtworkReview()
-                self.dismiss(animated: true)
             })
             .disposed(by: disposeBag)
     }

--- a/Gom4ziz/Source/Presenter/MyFeed/ZoomableImageViewController.swift
+++ b/Gom4ziz/Source/Presenter/MyFeed/ZoomableImageViewController.swift
@@ -43,7 +43,7 @@ private extension ZoomableImageViewController {
     func setUpUI() {
         self.view.backgroundColor = .gray1
         self.view.addSubview(zoomableAsyncImageView)
-        self.zoomableAsyncImageView.addSubview(closeButton)
+        self.view.addSubview(closeButton)
     }
     
     func setConstraints() {

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/ArtworkIntroduction/ArtworkIntroductionModal.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/ArtworkIntroduction/ArtworkIntroductionModal.swift
@@ -114,6 +114,7 @@ extension ArtworkIntroductionModal {
         setUpArtistLabel()
         setUpIntroductionLabel()
         setUpKeyboardObserver()
+        setUpMyReviewTextView()
     }
 
 }
@@ -194,7 +195,7 @@ private extension ArtworkIntroductionModal {
             myReviewTextView.leftAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leftAnchor),
             myReviewTextView.rightAnchor.constraint(equalTo: scrollView.contentLayoutGuide.rightAnchor),
             myReviewTextView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
-            myReviewTextView.heightAnchor.constraint(equalToConstant: 140)
+            myReviewTextView.heightAnchor.constraint(greaterThanOrEqualToConstant: 140)
         ])
     }
 }
@@ -204,7 +205,7 @@ extension ArtworkIntroductionModal: UIScrollViewDelegate {
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         // 만약 scrollView를 위쪽으로 계속 스크롤하면, 모달을 닫는다!
-        guard scrollView.contentOffset.y < -100 else {
+        guard scrollView.contentOffset.y < -50 else {
             return
         }
         hideModal()
@@ -294,6 +295,10 @@ private extension ArtworkIntroductionModal {
         let contentInset = baseInsets
         scrollView.contentInset = contentInset
         scrollView.scrollIndicatorInsets = .zero
+    }
+
+    func setUpMyReviewTextView() {
+        myReviewTextView.isScrollEnabled = false
     }
 }
 

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/ArtworkIntroduction/ArtworkIntroductionView.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/ArtworkIntroduction/ArtworkIntroductionView.swift
@@ -15,6 +15,7 @@ final class ArtworkIntroductionView: BaseAutoLayoutUIView {
     private let artworkDescription: ArtworkDescription
     private let artworkImage: ZoomableAsyncImageView
     private let artworkModal: ArtworkIntroductionModal
+    private let grayBackground: UIView = UIView()
     private var isInitiated: Bool = false
 
     var review: ControlProperty<String> {
@@ -56,7 +57,11 @@ final class ArtworkIntroductionView: BaseAutoLayoutUIView {
 extension ArtworkIntroductionView {
 
     func addSubviews() {
-        addSubviews(artworkImage, artworkModal)
+        addSubviews(
+            grayBackground,
+            artworkImage,
+            artworkModal
+        )
     }
 
     func setUpConstraints() {
@@ -65,6 +70,7 @@ extension ArtworkIntroductionView {
 
     func setUpUI() {
         backgroundColor = .white
+        grayBackground.backgroundColor = .gray1
     }
 
     func hideKeyboard() {
@@ -83,6 +89,14 @@ private extension ArtworkIntroductionView {
             artworkImage.heightAnchor.constraint(equalTo: artworkImage.widthAnchor, multiplier: 1.487),
             artworkImage.centerXAnchor.constraint(equalTo: centerXAnchor),
             artworkImage.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor)
+        ])
+        grayBackground.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            grayBackground.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            grayBackground.leftAnchor.constraint(equalTo: leftAnchor),
+            grayBackground.rightAnchor.constraint(equalTo: rightAnchor),
+            grayBackground.bottomAnchor.constraint(equalTo: bottomAnchor)
+
         ])
     }
 

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/ArtworkIntroduction/ArtworkIntroductionViewController.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/ArtworkIntroduction/ArtworkIntroductionViewController.swift
@@ -77,11 +77,6 @@ private extension ArtworkIntroductionViewController {
             })
             .disposed(by: disposeBag)
 
-        viewModel
-            .canUpload
-            .bind(to: completeButton.rx.isEnabled)
-            .disposed(by: disposeBag)
-
         artworkIntroductionView
             .review
             .bind(to: viewModel.review)

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/ArtworkIntroduction/ArtworkIntroductionViewController.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/ArtworkIntroduction/ArtworkIntroductionViewController.swift
@@ -48,6 +48,11 @@ final class ArtworkIntroductionViewController: UIViewController {
     override func loadView() {
         self.view = artworkIntroductionView
     }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        showToastMessage(text: "문장을 꾹 눌러 하이라이팅 할 수 있어요", duration: 2)
+    }
 }
 
 // MARK: - 뷰모델 릴레이 옵저버 설정

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/ArtworkIntroduction/ArtworkIntroductionViewController.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/ArtworkIntroduction/ArtworkIntroductionViewController.swift
@@ -60,7 +60,7 @@ private extension ArtworkIntroductionViewController {
 
     func setUpObserver() {
         viewModel.addEvent
-            .asDriver()
+            .asDriver(onErrorJustReturn: .notRequested)
             .drive(onNext: { [unowned self] in
                 switch $0 {
                 case .notRequested: break

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionAnswerView.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionAnswerView.swift
@@ -16,6 +16,8 @@ final class QuestionAnswerView: BaseAutoLayoutUIView {
     private let questionView: QuestionView
     private let myThinkLabel: SectionTitleView = SectionTitleView(title: "나의 생각")
     private let disposeBag: DisposeBag = .init()
+    private let scrollView: UIScrollView = UIScrollView()
+    private let baseInsets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 16, bottom: 16, right: -16)
     let answerInputTextView: PlaceholderTextView = .init(placeholder: "내용을 입력하세요")
 
     init(artwork: Artwork) {
@@ -23,6 +25,7 @@ final class QuestionAnswerView: BaseAutoLayoutUIView {
         self.questionView = QuestionView(artwork: artwork)
         super.init(frame: .zero)
         self.backgroundColor = .white
+        self.setUpKeyboardObserver()
     }
 
     required init?(coder: NSCoder) {
@@ -35,38 +38,86 @@ final class QuestionAnswerView: BaseAutoLayoutUIView {
 extension QuestionAnswerView {
 
     func addSubviews() {
-        addSubview(questionView)
-        addSubview(myThinkLabel)
-        addSubview(answerInputTextView)
+        addSubview(scrollView)
+        scrollView.addSubviews(
+            questionView,
+            myThinkLabel,
+            answerInputTextView
+        )
     }
 
     func setUpConstraints() {
+
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            scrollView.leftAnchor.constraint(equalTo: leftAnchor),
+            scrollView.rightAnchor.constraint(equalTo: rightAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+            scrollView.contentLayoutGuide.widthAnchor.constraint(equalTo: scrollView.widthAnchor, constant: -32)
+        ])
+        scrollView.contentInset = baseInsets
+
         questionView.translatesAutoresizingMaskIntoConstraints = false
         questionView.setContentHuggingPriority(.defaultHigh, for: .vertical)
         NSLayoutConstraint.activate([
-            questionView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 12),
-            questionView.leftAnchor.constraint(equalTo: safeAreaLayoutGuide.leftAnchor, constant: 16),
-            questionView.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor, constant: -16)
+            questionView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 12),
+            questionView.leftAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leftAnchor),
+            questionView.rightAnchor.constraint(equalTo: scrollView.contentLayoutGuide.rightAnchor)
         ])
 
         myThinkLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            myThinkLabel.leftAnchor.constraint(equalTo: questionView.leftAnchor),
+            myThinkLabel.leftAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leftAnchor),
             myThinkLabel.topAnchor.constraint(equalTo: questionView.bottomAnchor, constant: 20),
-            myThinkLabel.rightAnchor.constraint(equalTo: questionView.rightAnchor)
+            myThinkLabel.rightAnchor.constraint(equalTo: scrollView.contentLayoutGuide.rightAnchor)
         ])
 
         answerInputTextView.translatesAutoresizingMaskIntoConstraints = false
+        answerInputTextView.isScrollEnabled = false
         NSLayoutConstraint.activate([
-            answerInputTextView.leftAnchor.constraint(equalTo: questionView.leftAnchor),
-            answerInputTextView.rightAnchor.constraint(equalTo: questionView.rightAnchor),
+            answerInputTextView.leftAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leftAnchor),
+            answerInputTextView.rightAnchor.constraint(equalTo: scrollView.contentLayoutGuide.rightAnchor),
             answerInputTextView.topAnchor.constraint(equalTo: myThinkLabel.bottomAnchor, constant: 20),
-            answerInputTextView.bottomAnchor.constraint(equalTo: keyboardLayoutGuide.topAnchor, constant: -16)
+            answerInputTextView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            answerInputTextView.heightAnchor.constraint(greaterThanOrEqualToConstant: 200)
         ])
     }
 
     func setUpUI() {
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTapGesture(sender:))))
+    }
+
+}
+
+// MARK: - 키보드가 올라올 시 스크롤뷰의 콘텐츠 오프셋을 조정하는 부분입니다.
+private extension QuestionAnswerView {
+
+    func setUpKeyboardObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillAppear), name: UIResponder.keyboardWillShowNotification, object: nil)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
+    @objc func keyboardWillAppear(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+                let keyboardFrame = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
+                    return
+            }
+            let contentInset = UIEdgeInsets(
+                top: 0.0,
+                left: 16,
+                bottom: keyboardFrame.size.height + 16,
+                right: -16)
+            scrollView.contentInset = contentInset
+        scrollView.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: keyboardFrame.size.height, right: 0)
+        scrollView.scrollToBottom()
+    }
+
+    @objc func keyboardWillHide() {
+        let contentInset = baseInsets
+        scrollView.contentInset = contentInset
+        scrollView.scrollIndicatorInsets = .zero
     }
 
 }

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionAnswerViewModel.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionAnswerViewModel.swift
@@ -19,7 +19,7 @@ final class QuestionAnswerViewModel {
     let artwork: Artwork
     // MARK: - Rx Relays
     let artworkDescriptionRelay: BehaviorRelay<Loadable<ArtworkDescription>> = .init(value: .notRequested)
-    let addEvent: BehaviorRelay<Loadable<Void>> = .init(value: .notRequested)
+    let addEvent: PublishRelay<Loadable<Void>> = .init()
     let myAnswer: BehaviorRelay<String> = .init(value: "")
     let review: BehaviorRelay<String> = .init(value: "")
     let highlights: BehaviorRelay<[Highlight]> = .init(value: [])

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionAnswerViewModel.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionAnswerViewModel.swift
@@ -23,7 +23,6 @@ final class QuestionAnswerViewModel {
     let myAnswer: BehaviorRelay<String> = .init(value: "")
     let review: BehaviorRelay<String> = .init(value: "")
     let highlights: BehaviorRelay<[Highlight]> = .init(value: [])
-    let canUpload: BehaviorRelay<Bool> = .init(value: false)
 
     init(
         userId: String,
@@ -35,7 +34,6 @@ final class QuestionAnswerViewModel {
         self.artwork = artwork
         self.fetchDescriptionUsecase = fetchDescriptionUsecase
         self.addReviewUsecase = addReviewUsecase
-        self.setUpObserver()
     }
 
     // 디버그용 생성자
@@ -46,7 +44,6 @@ final class QuestionAnswerViewModel {
         self.artworkDescriptionRelay.accept(.loaded(ArtworkDescription.mockData))
         self.fetchDescriptionUsecase = RealFetchArtworkDescriptionUseCase()
         self.addReviewUsecase = RealArtworkReviewUsecase()
-        self.setUpObserver()
     }
     #endif
 
@@ -80,22 +77,6 @@ final class QuestionAnswerViewModel {
                 // 업로드 도중 실패 시
                 self?.addEvent.accept(.failed(error))
             })
-            .disposed(by: disposeBag)
-    }
-
-}
-
-// MARK: - 옵저버 설정
-private extension QuestionAnswerViewModel {
-
-    func setUpObserver() {
-
-        // 질문 답변과, 감상평을 모두 작성해야 등록가능!
-        Observable.combineLatest(myAnswer, review)
-            .map { (answer, review) in
-                !answer.isEmpty && !review.isEmpty
-            }
-            .bind(to: canUpload)
             .disposed(by: disposeBag)
     }
 

--- a/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionView.swift
+++ b/Gom4ziz/Source/Presenter/QuestionAnswer/QuestionAnswerPage/QuestionView.swift
@@ -68,6 +68,7 @@ private extension QuestionView {
 
     func setUpInfoContainerConstaints() {
         infoContainer.translatesAutoresizingMaskIntoConstraints = false
+        infoContainer.backgroundColor = .black.withAlphaComponent(0.3)
         NSLayoutConstraint.activate([
             infoContainer.topAnchor.constraint(equalTo: topAnchor),
             infoContainer.leftAnchor.constraint(equalTo: leftAnchor),


### PR DESCRIPTION
## 작업 내용 (Content)
- 질문이 더 잘보이도록 작품 사진 위에 반투명한 배경을 추가함
- TextView가 입력한 텍스트에 따라 길어지도록 수정하였음
- 작품 이미지 뒤에 회색 배경을 추가했습니다.
작품 설명 모달의 감상평 작성 텍스트뷰도, 길이에 따라 늘어나도록 했습니다.
더보기 버튼과 설명 사이의 간격을 늘리고, 버튼 클릭 영역을 패딩을 적용해 늘렸습니다.
- 더블 탭 제스쳐로 이미지를 확대할 수 있도록 수정하였습니다.
- 확대 가능한 이미지 뷰의 스케일이 1일 때, 스크롤이 불가능하도록 수정함
- 작품 설명과 하이라이트는, 변경될 가능성이 없음 (하이라이트의 경우 편집이 불가능함) 따라서 캐시를 활용합니다.
- AspectFit 사이즈에 맞추라는 변수가 true일 때, height가 350혹은 width와 height 비율에 맞게 동적으로 변하도록 변경함
- 어떤 Action의 Event를 방출하는 Relay를 Publish로 바꿈.
## Review points
- 리뷰어가 중점적으로 리뷰해줬으면 하는 포인트

## 기타 사항 (Etc)
- 작업하면서 고민이 되었던 부분이나 질문 사항 등

## 관련 사진 gif 및 (Optional)

## References (Optional)
- 참고한 사이트나 정리한 wiki 링크를 넣어주세요
- [링크이름](링크)
