### PR TITLE
feat: firebase의 ArtworkDescription에 \n이 있을 시 UI에서 개행이 되도록 코드 추가

### DIFF
--- a/Gom4ziz/Source/Domain/Model/ArtworkDescription.swift
+++ b/Gom4ziz/Source/Domain/Model/ArtworkDescription.swift
@@ -10,6 +10,18 @@ import Foundation
 struct ArtworkDescription: Codable, Identifiable {
     let id: Int
     let content: String
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(Int.self, forKey: .id)
+        let tempContent = try container.decode(String.self, forKey: .content)
+        self.content = tempContent.convertNewLine
+    }
+    
+    init(id: Int, content: String) {
+        self.id = id
+        self.content = content
+    }
 }
 
 extension ArtworkDescription: CustomStringConvertible {

--- a/Gom4ziz/Source/Extension/String.swift
+++ b/Gom4ziz/Source/Extension/String.swift
@@ -1,0 +1,14 @@
+//
+//  String.swift
+//  Gom4ziz
+//
+//  Created by 이가은 on 2022/12/09.
+//
+
+import Foundation
+
+extension String {
+    var convertNewLine: String {
+        return self.replacingOccurrences(of: "\\n", with: "\n")
+      }
+}

--- a/Gom4ziz/Source/Presenter/Main/WeeklyQuestion/MainQuestionView.swift
+++ b/Gom4ziz/Source/Presenter/Main/WeeklyQuestion/MainQuestionView.swift
@@ -104,6 +104,7 @@ private extension MainQuestionView {
     func setUpQuestionLabel() {
         questionLabel.text = artwork.question
         questionLabel.textStyle(.Display1, lineHeightMultiple: 1.5, alignment: .left, UIColor.white)
+        questionLabel.lineBreakStrategy = .hangulWordPriority
         questionNumberLabel.textColor = .white
         questionLabel.numberOfLines = 0
         questionLabel.lineBreakMode = .byWordWrapping


### PR DESCRIPTION
## Close Issues
- Pull Request와 관련된 Issue가 있다면 나열합니다.
🔒 Close #192

## 작업 내용 (Content)
- 작업한 내용을 나열 후 설명
1) firebase의 ArtworkDescription에 \n이 있을 시 UI에서 개행이 되도록 코드 추가했습니다.
- firebase에서 ArtworkDescription을 등록할 시에 \n을 입력하면 \\n으로 값이 들어가서 UI에서 좌측과 같이 보이게 됩니다. 
그래서 firebase에서 값을 불러왔을 때 \\n을 다시 \n으로 변경하는 코드를 추가함으로 오른쪽 그림처럼 개행이 되도록 변경했습니다.
<table> 
        <tr>
           <td><img width="251" alt="스크린샷 2022-12-09 오전 5 25 02" src="https://user-images.githubusercontent.com/82457928/206560493-a9fd3e6e-2db9-4846-9fca-4897a96196ca.png"></td>
           <td><img width="251" alt="스크린샷 2022-12-09 오전 5 25 58" src="https://user-images.githubusercontent.com/82457928/206560509-2a20d7f8-d6a6-4ed6-b181-a5d99f35f770.png"></td>
        </tr>
</table> 

2) firebase에 모든 작품의 ArtworkDescription에 필요한 개행(\n)을 추가해서 재등록했습니다.

@HoJongE ArtworkDescription 내용 다듬어주신 후에 \n\n(2번) 추가하고 맞춤법 검사기 돌려서 수정한 후에 파베에 올려주시길 바랍니다.
별표 있는 거(1,2, 3,5,8)는 제가 둘 다 확인 후에 파베에 올렸습니다유 ~

## Review points
- 리뷰어가 중점적으로 리뷰해줬으면 하는 포인트

## 기타 사항 (Etc)
- 작업하면서 고민이 되었던 부분이나 질문 사항 등
1) 작품 질문 같은 경우에도 개행이 되면 좋을 것 같아서 오늘 이솝과 쑤에게 질문을 하려 합니다.
<img width="252" alt="스크린샷 2022-12-09 오전 5 28 12" src="https://user-images.githubusercontent.com/82457928/206560878-68eb71b2-b16b-4ba3-9216-930ae8ba29be.png">

2) 구현 방법에 대한 고민<\br>

(방법1)
처음에는 [c8b7d03](https://github.com/DeveloperAcademy-POSTECH/MacC_Team_Beartear/pull/194/commits/c8b7d039052f52a398bc681ded5ee328f14708f7)처럼 repository에서 map으로 개행이 되게끔 바꿨는데, convertNewLine을 모델에서 호출되는 게 깔끔할 거라고 생각했습니다. 

(방법2)
하지만, 개행을 하는 과정이 model에서 이뤄지는 게 맞다고 생각해서, [de28150](https://github.com/DeveloperAcademy-POSTECH/MacC_Team_Beartear/pull/194/commits/de2815060a99e02568755ec14f45c24f7d271ee0)처럼 init(from decoder: Decoder)을 수정했습니다.<\br>
둘 중 어느 방법이 나은지 궁금합니다. 
## 관련 사진 gif 및 (Optional)

## References (Optional)
- 참고한 사이트나 정리한 wiki 링크를 넣어주세요
- [replacingOccurrences(of:with:)](https://developer.apple.com/documentation/foundation/nsstring/1412937-replacingoccurrences)
